### PR TITLE
Add javadoc for the poll-and-confirm process

### DIFF
--- a/src/main/java/no/digipost/signature/client/direct/SignatureClient.java
+++ b/src/main/java/no/digipost/signature/client/direct/SignatureClient.java
@@ -48,11 +48,32 @@ public class SignatureClient {
         return fromJaxb(xmlSignatureJobResponse);
     }
 
+
+    /**
+     * Get the current status for the given {@link StatusReference}, which references the status for a specific job.
+     * When processing of the status is complete (e.g. retrieving {@link #getPAdES(PAdESReference) PAdES} and/or
+     * {@link #getXAdES(XAdESReference) XAdES} documents for a  {@link SignatureJobStatus#SIGNED signed} job),
+     * the returned status must be {@link #confirm(SignatureJobStatusResponse) confirmed}.
+     *
+     * @param statusReference the reference to the status of a specific job.
+     * @return the {@link SignatureJobStatusResponse} for the job referenced by the given {@link StatusReference},
+     *         never {@code null}.
+     */
     public SignatureJobStatusResponse getStatus(StatusReference statusReference) {
         XMLDirectSignatureJobStatusResponse xmlSignatureJobStatusResponse = client.sendSignatureJobStatusRequest(statusReference.getStatusUrl());
         return fromJaxb(xmlSignatureJobStatusResponse);
     }
 
+
+    /**
+     * Confirms that the status retrieved from {@link #getStatus(StatusReference)} is received.
+     * If the confirmed {@link SignatureJobStatus} is a terminal status
+     * (e.g. {@link SignatureJobStatus#SIGNED signed} or {@link SignatureJobStatus#CANCELLED cancelled}),
+     * the Signature service may make the job's associated resources unavailable through the API when
+     * receiving the confirmation.
+     *
+     * @param receivedStatusResponse the updated status retrieved from {@link #getStatusChange()}.
+     */
     public void confirm(SignatureJobStatusResponse receivedStatusResponse) {
         client.confirm(receivedStatusResponse);
     }

--- a/src/main/java/no/digipost/signature/client/direct/SignatureJobStatus.java
+++ b/src/main/java/no/digipost/signature/client/direct/SignatureJobStatus.java
@@ -19,8 +19,20 @@ import no.digipost.signering.schema.v1.signature_job.XMLDirectSignatureJobStatus
 
 public enum SignatureJobStatus {
 
+    /**
+     * The signature job is created, and the receiver is currently doing the
+     * signing ceremony.
+     */
     CREATED,
+
+    /**
+     * The document(s) of the job has been signed by the receiver.
+     */
     SIGNED,
+
+    /**
+     * The signature job has been cancelled.
+     */
     CANCELLED;
 
     public static SignatureJobStatus fromXmlType(XMLDirectSignatureJobStatus xmlJobStatus) {

--- a/src/main/java/no/digipost/signature/client/portal/PortalClient.java
+++ b/src/main/java/no/digipost/signature/client/portal/PortalClient.java
@@ -46,11 +46,12 @@ public class PortalClient {
 
     /**
      * If there is a job with an updated {@link PortalSignatureJobStatus status}, the returned object contains
-     * necessary information to act on the status change. If no jobs has changed status since the last call to this
-     * method, {@link PortalSignatureJobStatusChanged#NO_UPDATED_STATUS} is returned. The returned object can be queried using
+     * necessary information to act on the status change. The returned object can be queried using
      * {@link PortalSignatureJobStatusChanged#is(PortalSignatureJobStatus) .is(}{@link PortalSignatureJobStatus#NO_CHANGES NO_CHANGES)}
-     * to determine if there has been a status change. When processing of the status change is complete, the returned
-     * {@code PortalSignatureJobStatus} must be {@link #confirm(PortalSignatureJobStatusChanged) confirmed}.
+     * to determine if there has been a status change. When processing of the status change is complete, (e.g. retrieving
+     * {@link #getPAdES(PAdESReference) PAdES} and/or {@link #getXAdES(XAdESReference) XAdES} documents for a
+     * {@link PortalSignatureJobStatus#SIGNED signed} job), the returned
+     * status must be {@link #confirm(PortalSignatureJobStatusChanged) confirmed}.
      *
      * @return the changed status for a job, or {@link PortalSignatureJobStatusChanged#NO_UPDATED_STATUS NO_UPDATED_STATUS},
      *         never {@code null}.
@@ -63,7 +64,8 @@ public class PortalClient {
 
     /**
      * Confirms that the status retrieved from {@link #getStatusChange()} is received and may
-     * be discarded by the Signature service and not retrieved again.
+     * be discarded by the Signature service and not retrieved again. Calling this method for
+     * the {@link PortalSignatureJobStatus#NO_CHANGES NO_CHANGES} status update has no effect.
      *
      * @param receivedStatusChanged the updated status retrieved from {@link #getStatusChange()}.
      */

--- a/src/main/java/no/digipost/signature/client/portal/PortalSignatureJobStatusChanged.java
+++ b/src/main/java/no/digipost/signature/client/portal/PortalSignatureJobStatusChanged.java
@@ -34,6 +34,10 @@ import static no.digipost.signature.client.portal.PortalSignatureJobStatus.NO_CH
 public class PortalSignatureJobStatusChanged implements Confirmable {
 
 
+    /**
+     * This instance indicates that there has been no status updates since the last poll request for
+     * {@link PortalSignatureJobStatusChanged}. Its status is {@link PortalSignatureJobStatus#NO_CHANGES NO_CHANGES}.
+     */
     public static final PortalSignatureJobStatusChanged NO_UPDATED_STATUS = new PortalSignatureJobStatusChanged(null, NO_CHANGES, null, null, null) {
         @Override
         public long getSignatureJobId() {


### PR DESCRIPTION
Small PR containing some javadocs. Would usually just commit this to master but thought it would be assuring to have someone to look it over and verify that I have got the polling-and-confirming process right.