### PR TITLE
API change: confirmation-url moved + refactoring

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
 install:
   - export mavenBuildGoal="$([[ ${TRAVIS_TAG} == '' ]] && echo deploy || echo verify)"
   - echo "Maven will ${mavenBuildGoal}"
-  - mvn clean ${mavenBuildGoal} --settings ~/.m2/deploy-settings.xml
+  - mvn clean ${mavenBuildGoal} -U --settings ~/.m2/deploy-settings.xml
 
 script:
   - echo "no build script"

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <name>Signature API-client Java</name>
     <groupId>no.digipost.signature</groupId>
     <artifactId>signature-api-client-java</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0.API-MINORCHANGE-CONFIRMATIONURL-SNAPSHOT</version>
 
     <parent>
         <groupId>no.digipost</groupId>
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>no.digipost.signature</groupId>
             <artifactId>signature-api-specification</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>1.0.API-MINORCHANGE-CONFIRMATIONURL-SNAPSHOT</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/src/main/java/no/digipost/signature/client/core/ConfirmationReference.java
+++ b/src/main/java/no/digipost/signature/client/core/ConfirmationReference.java
@@ -17,9 +17,13 @@ package no.digipost.signature.client.core;
 
 public class ConfirmationReference {
 
+    public static ConfirmationReference of(String url) {
+        return url == null ? null : new ConfirmationReference(url);
+    }
+
     private final String url;
 
-    public ConfirmationReference(String url) {
+    private ConfirmationReference(String url) {
         this.url = url;
     }
 

--- a/src/main/java/no/digipost/signature/client/core/PAdESReference.java
+++ b/src/main/java/no/digipost/signature/client/core/PAdESReference.java
@@ -17,9 +17,13 @@ package no.digipost.signature.client.core;
 
 public class PAdESReference {
 
+    public static PAdESReference of(String url) {
+        return url == null ? null : new PAdESReference(url);
+    }
+
     private final String pAdESUrl;
 
-    public PAdESReference(String pAdESUrl) {
+    private PAdESReference(String pAdESUrl) {
         this.pAdESUrl = pAdESUrl;
     }
 

--- a/src/main/java/no/digipost/signature/client/core/XAdESReference.java
+++ b/src/main/java/no/digipost/signature/client/core/XAdESReference.java
@@ -17,9 +17,13 @@ package no.digipost.signature.client.core;
 
 public class XAdESReference {
 
+    public static XAdESReference of(String url) {
+        return url == null ? null : new XAdESReference(url);
+    }
+
     private final String xAdESUrl;
 
-    public XAdESReference(String xAdESUrl) {
+    private XAdESReference(String xAdESUrl) {
         this.xAdESUrl = xAdESUrl;
     }
 

--- a/src/main/java/no/digipost/signature/client/core/internal/ClientHelper.java
+++ b/src/main/java/no/digipost/signature/client/core/internal/ClientHelper.java
@@ -143,15 +143,17 @@ public class ClientHelper {
     }
 
     public void confirm(Confirmable confirmable) {
-        Response response = httpClient.target(confirmable.getConfirmationReference().getConfirmationUrl())
-                .request()
-                .accept(APPLICATION_XML_TYPE)
-                .header("Content-Length", 0)
-                .post(Entity.entity(null, APPLICATION_XML_TYPE));
-        Status status = Status.fromStatusCode(response.getStatus());
-        if (status != OK) {
-            XMLError error = response.readEntity(XMLError.class);
-            throw new UnexpectedResponseException(error, status, OK);
+        if (confirmable.getConfirmationReference() != null) {
+            Response response = httpClient.target(confirmable.getConfirmationReference().getConfirmationUrl())
+                    .request()
+                    .accept(APPLICATION_XML_TYPE)
+                    .header("Content-Length", 0)
+                    .post(Entity.entity(null, APPLICATION_XML_TYPE));
+            Status status = Status.fromStatusCode(response.getStatus());
+            if (status != OK) {
+                XMLError error = response.readEntity(XMLError.class);
+                throw new UnexpectedResponseException(error, status, OK);
+            }
         }
     }
 }

--- a/src/main/java/no/digipost/signature/client/direct/JaxbEntityMapping.java
+++ b/src/main/java/no/digipost/signature/client/direct/JaxbEntityMapping.java
@@ -15,7 +15,10 @@
  */
 package no.digipost.signature.client.direct;
 
+import no.digipost.signature.client.core.ConfirmationReference;
+import no.digipost.signature.client.core.PAdESReference;
 import no.digipost.signature.client.core.Sender;
+import no.digipost.signature.client.core.XAdESReference;
 import no.digipost.signering.schema.v1.common.*;
 import no.digipost.signering.schema.v1.signature_job.*;
 
@@ -47,13 +50,16 @@ final class JaxbEntityMapping {
     }
 
     static SignatureJobStatusResponse fromJaxb(XMLDirectSignatureJobStatusResponse statusResponse) {
+        XMLJobSignedLinks links;
         if (statusResponse.getStatus() == SIGNED) {
-            XMLJobSignedLinks links = statusResponse.getAdditionalInfo().getJobSignedInfo().getLinks();
-            return new SignatureJobStatusResponse(statusResponse.getSignatureJobId(), SignatureJobStatus.fromXmlType(statusResponse.getStatus()),
-                    links.getXadesUrl(), links.getPadesUrl(), links.getConfirmationUrl());
+            links = statusResponse.getAdditionalInfo().getJobSignedInfo().getLinks();
         } else {
-            return new SignatureJobStatusResponse(statusResponse.getSignatureJobId(), SignatureJobStatus.fromXmlType(statusResponse.getStatus()));
-
+            links = new XMLJobSignedLinks();
         }
+        return new SignatureJobStatusResponse(
+                statusResponse.getSignatureJobId(), SignatureJobStatus.fromXmlType(statusResponse.getStatus()),
+                ConfirmationReference.of(statusResponse.getConfirmationUrl()),
+                XAdESReference.of(links.getXadesUrl()),
+                PAdESReference.of(links.getPadesUrl()));
     }
 }

--- a/src/main/java/no/digipost/signature/client/direct/SignatureClient.java
+++ b/src/main/java/no/digipost/signature/client/direct/SignatureClient.java
@@ -17,6 +17,7 @@ package no.digipost.signature.client.direct;
 
 import no.digipost.signature.client.ClientConfiguration;
 import no.digipost.signature.client.asice.DocumentBundle;
+import no.digipost.signature.client.core.ConfirmationReference;
 import no.digipost.signature.client.core.PAdESReference;
 import no.digipost.signature.client.core.XAdESReference;
 import no.digipost.signature.client.core.internal.ClientHelper;
@@ -70,7 +71,8 @@ public class SignatureClient {
      * If the confirmed {@link SignatureJobStatus} is a terminal status
      * (e.g. {@link SignatureJobStatus#SIGNED signed} or {@link SignatureJobStatus#CANCELLED cancelled}),
      * the Signature service may make the job's associated resources unavailable through the API when
-     * receiving the confirmation.
+     * receiving the confirmation. Calling this method for a response with no {@link ConfirmationReference}
+     * has no effect.
      *
      * @param receivedStatusResponse the updated status retrieved from {@link #getStatusChange()}.
      */

--- a/src/main/java/no/digipost/signature/client/direct/SignatureJobStatusResponse.java
+++ b/src/main/java/no/digipost/signature/client/direct/SignatureJobStatusResponse.java
@@ -25,20 +25,16 @@ public class SignatureJobStatusResponse implements Confirmable {
 
     private final long signatureJobId;
     private final SignatureJobStatus status;
+    private final ConfirmationReference confirmationReference;
     private final XAdESReference xAdESUrl;
     private final PAdESReference pAdESUrl;
-    private final ConfirmationReference confirmationReference;
 
-    public SignatureJobStatusResponse(long signatureJobId, SignatureJobStatus status, String xAdESUrl, String pAdESUrl, String confirmationUrl) {
+    public SignatureJobStatusResponse(long signatureJobId, SignatureJobStatus status, ConfirmationReference confirmationUrl, XAdESReference xAdESUrl, PAdESReference pAdESUrl) {
         this.signatureJobId = signatureJobId;
         this.status = status;
-        this.xAdESUrl = new XAdESReference(xAdESUrl);
-        this.pAdESUrl = new PAdESReference(pAdESUrl);
-        this.confirmationReference = new ConfirmationReference(confirmationUrl);
-    }
-
-    public SignatureJobStatusResponse(long signatureJobId, SignatureJobStatus status) {
-        this(signatureJobId, status, null, null, null);
+        this.confirmationReference = confirmationUrl;
+        this.xAdESUrl = xAdESUrl;
+        this.pAdESUrl = pAdESUrl;
     }
 
     public long getSignatureJobId() {

--- a/src/main/java/no/digipost/signature/client/portal/JaxbEntityMapping.java
+++ b/src/main/java/no/digipost/signature/client/portal/JaxbEntityMapping.java
@@ -15,11 +15,16 @@
  */
 package no.digipost.signature.client.portal;
 
+import no.digipost.signature.client.core.ConfirmationReference;
+import no.digipost.signature.client.core.PAdESReference;
 import no.digipost.signature.client.core.Sender;
+import no.digipost.signature.client.core.XAdESReference;
 import no.digipost.signering.schema.v1.common.*;
 import no.digipost.signering.schema.v1.portal_signature_job.XMLJobSignedLinks;
 import no.digipost.signering.schema.v1.portal_signature_job.XMLPortalSignatureJobRequest;
 import no.digipost.signering.schema.v1.portal_signature_job.XMLPortalSignatureJobStatusChangeResponse;
+
+import static no.digipost.signering.schema.v1.portal_signature_job.XMLPortalSignatureJobStatus.SIGNED;
 
 final class JaxbEntityMapping {
 
@@ -39,8 +44,16 @@ final class JaxbEntityMapping {
 
 
     static PortalSignatureJobStatusChanged fromJaxb(XMLPortalSignatureJobStatusChangeResponse statusChange) {
-        XMLJobSignedLinks links = statusChange.getAdditionalInfo().getJobSignedInfo().getLinks();
-        return new PortalSignatureJobStatusChanged(statusChange.getSignatureJobId(), PortalSignatureJobStatus.fromXmlType(statusChange.getStatus()),
-                links.getXadesUrl(), links.getPadesUrl(), links.getConfirmationUrl());
+        XMLJobSignedLinks links;
+        if (statusChange.getStatus() == SIGNED) {
+            links = statusChange.getAdditionalInfo().getJobSignedInfo().getLinks();
+        } else {
+            links = new XMLJobSignedLinks();
+        }
+        return new PortalSignatureJobStatusChanged(
+                statusChange.getSignatureJobId(), PortalSignatureJobStatus.fromXmlType(statusChange.getStatus()),
+                ConfirmationReference.of(statusChange.getConfirmationUrl()),
+                XAdESReference.of(links.getXadesUrl()),
+                PAdESReference.of(links.getPadesUrl()));
     }
 }

--- a/src/main/java/no/digipost/signature/client/portal/PortalClient.java
+++ b/src/main/java/no/digipost/signature/client/portal/PortalClient.java
@@ -16,6 +16,7 @@
 package no.digipost.signature.client.portal;
 
 import no.digipost.signature.client.ClientConfiguration;
+import no.digipost.signature.client.core.ConfirmationReference;
 import no.digipost.signature.client.core.PAdESReference;
 import no.digipost.signature.client.core.XAdESReference;
 import no.digipost.signature.client.core.internal.ClientHelper;
@@ -25,7 +26,6 @@ import java.io.InputStream;
 
 import static no.digipost.signature.client.asice.CreateASiCE.createASiCE;
 import static no.digipost.signature.client.portal.JaxbEntityMapping.toJaxb;
-import static no.digipost.signature.client.portal.PortalSignatureJobStatus.NO_CHANGES;
 import static no.digipost.signature.client.portal.PortalSignatureJobStatusChanged.NO_UPDATED_STATUS;
 
 public class PortalClient {
@@ -64,15 +64,12 @@ public class PortalClient {
 
     /**
      * Confirms that the status retrieved from {@link #getStatusChange()} is received and may
-     * be discarded by the Signature service and not retrieved again. Calling this method for
-     * the {@link PortalSignatureJobStatus#NO_CHANGES NO_CHANGES} status update has no effect.
+     * be discarded by the Signature service and not retrieved again. Calling this method on
+     * a status update with no {@link ConfirmationReference} has no effect.
      *
      * @param receivedStatusChanged the updated status retrieved from {@link #getStatusChange()}.
      */
     public void confirm(PortalSignatureJobStatusChanged receivedStatusChanged) {
-        if (receivedStatusChanged.is(NO_CHANGES)) {
-            return;
-        }
         client.confirm(receivedStatusChanged);
     }
 

--- a/src/main/java/no/digipost/signature/client/portal/PortalSignatureJobStatusChanged.java
+++ b/src/main/java/no/digipost/signature/client/portal/PortalSignatureJobStatusChanged.java
@@ -55,16 +55,16 @@ public class PortalSignatureJobStatusChanged implements Confirmable {
 
     private final Long signatureJobId;
     private final PortalSignatureJobStatus status;
-    private final XAdESReference xAdESUrl;
-    private final PAdESReference pAdESUrl;
+    private final XAdESReference xAdESReference;
+    private final PAdESReference pAdESReference;
     private final ConfirmationReference confirmationReference;
 
-    PortalSignatureJobStatusChanged(Long signatureJobId, PortalSignatureJobStatus status, String xAdESUrl, String pAdESUrl, String confirmationUrl) {
+    PortalSignatureJobStatusChanged(Long signatureJobId, PortalSignatureJobStatus status, ConfirmationReference confirmationReference, XAdESReference xAdESReference, PAdESReference pAdESReference) {
         this.signatureJobId = signatureJobId;
         this.status = status;
-        this.xAdESUrl = new XAdESReference(xAdESUrl);
-        this.pAdESUrl = new PAdESReference(pAdESUrl);
-        this.confirmationReference = new ConfirmationReference(confirmationUrl);
+        this.xAdESReference = xAdESReference;
+        this.pAdESReference = pAdESReference;
+        this.confirmationReference = confirmationReference;
     }
 
     public long getSignatureJobId() {
@@ -80,11 +80,11 @@ public class PortalSignatureJobStatusChanged implements Confirmable {
     }
 
     public XAdESReference getxAdESUrl() {
-        return xAdESUrl;
+        return xAdESReference;
     }
 
     public PAdESReference getpAdESUrl() {
-        return pAdESUrl;
+        return pAdESReference;
     }
 
     @Override


### PR DESCRIPTION
More generic and uniform handling of the confirmation-url. It's presence is used transparently by the client library to decide if a confirmation request should be made.