### PR TITLE
Better error message on Java runtime without TLS v1.2 support

### DIFF
--- a/src/main/java/no/digipost/signature/client/core/internal/ClientExceptionMapper.java
+++ b/src/main/java/no/digipost/signature/client/core/internal/ClientExceptionMapper.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) Posten Norge AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package no.digipost.signature.client.core.internal;
 
 import no.digipost.signature.client.core.exceptions.ConfigurationException;

--- a/src/main/java/no/digipost/signature/client/core/internal/ClientExceptionMapper.java
+++ b/src/main/java/no/digipost/signature/client/core/internal/ClientExceptionMapper.java
@@ -1,0 +1,21 @@
+package no.digipost.signature.client.core.internal;
+
+import no.digipost.signature.client.core.exceptions.ConfigurationException;
+
+import javax.net.ssl.SSLException;
+import javax.ws.rs.ProcessingException;
+
+class ClientExceptionMapper {
+
+    public RuntimeException map(ProcessingException e) {
+        if (e.getCause() instanceof SSLException) {
+            String sslExceptionMessage = e.getCause().getMessage();
+            if (sslExceptionMessage != null && sslExceptionMessage.contains("protocol_version")) {
+                return new ConfigurationException("Invalid TLS protocol version. This will typically happen if you're running on an older Java version, which doesn't support TLS 1.2. " +
+                        "Java 7 needs to be explicitly configured to support TLS 1.2. See 'JSSE tuning parameters' at https://blogs.oracle.com/java-platform-group/entry/diagnosing_tls_ssl_and_https.", e);
+            }
+        }
+        return e;
+    }
+
+}

--- a/src/main/java/no/digipost/signature/client/core/internal/ClientHelper.java
+++ b/src/main/java/no/digipost/signature/client/core/internal/ClientHelper.java
@@ -111,9 +111,9 @@ public class ClientHelper {
     }
 
     public void cancel(final Cancellable cancellable) {
-        call(new Function() {
+        call(new Runnable() {
             @Override
-            void call() {
+            public void run() {
                 if (cancellable.getCancellationUrl() != null) {
                     String url = cancellable.getCancellationUrl().getUrl();
                     Response response = postEmptyEntity(url);
@@ -154,9 +154,9 @@ public class ClientHelper {
     }
 
     public void confirm(final Confirmable confirmable) {
-        call(new Function() {
+        call(new Runnable() {
             @Override
-            void call() {
+            public void run() {
                 if (confirmable.getConfirmationReference() != null) {
                     String url = confirmable.getConfirmationReference().getConfirmationUrl();
                     LOG.info("Sends confirmation for '{}' to URL {}", confirmable, url);
@@ -180,11 +180,11 @@ public class ClientHelper {
         }
     }
 
-    private void call(final Function function) {
+    private void call(final Runnable function) {
         call(new Producer<Void>() {
             @Override
             Void call() {
-                function.call();
+                function.run();
                 return null;
             }
         });
@@ -192,10 +192,6 @@ public class ClientHelper {
 
     private abstract class Producer<T> {
         abstract T call();
-    }
-
-    private abstract class Function {
-        abstract void call();
     }
 
     private class UsingBodyParts {


### PR DESCRIPTION
Java 7 ships with TLS v1.2 support disabled by default. This provides a more instructive error message when connection fails due to unrecognized TLS version.

Also introduces a generic mechanism for mapping exceptions from the http client.