### PR TITLE
Ny SignatureStatus NOT_APPLICABLE

### DIFF
--- a/src/main/java/no/digipost/signature/client/portal/SignatureStatus.java
+++ b/src/main/java/no/digipost/signature/client/portal/SignatureStatus.java
@@ -113,4 +113,9 @@ public final class SignatureStatus {
     public int hashCode() {
         return Objects.hash(identifier);
     }
+
+    @Override
+    public String toString() {
+        return identifier;
+    }
 }

--- a/src/main/java/no/digipost/signature/client/portal/SignatureStatus.java
+++ b/src/main/java/no/digipost/signature/client/portal/SignatureStatus.java
@@ -22,13 +22,52 @@ import static java.util.Arrays.asList;
 
 public final class SignatureStatus {
 
+    /**
+     * The signer has rejected to sign the document.
+     */
     public static final SignatureStatus REJECTED = new SignatureStatus("REJECTED");
+
+    /**
+     * This signer has been cancelled by the sender, and will not be able to sign the document.
+     */
     public static final SignatureStatus CANCELLED = new SignatureStatus("CANCELLED");
+
+    /**
+     * This signer is reserved from receiving documents electronically, and will not receive
+     * the document for signing.
+     */
     public static final SignatureStatus RESERVED = new SignatureStatus("RESERVED");
+
+    /**
+     * We were not able to locate any channels (email, SMS) for notifying the signer to sign the document.
+     */
     public static final SignatureStatus CONTACT_INFORMATION_MISSING = new SignatureStatus("CONTACT_INFORMATION_MISSING");
+
+    /**
+     * The signer has not made a decision to either sign or reject the document within the
+     * specified time limit,
+     */
     public static final SignatureStatus EXPIRED = new SignatureStatus("EXPIRED");
+
+    /**
+     * The signer has yet to review the document and decide if she/he wants to sign or
+     * reject it.
+     */
     public static final SignatureStatus WAITING = new SignatureStatus("WAITING");
+
+    /**
+     * The signer has successfully signed the document.
+     */
     public static final SignatureStatus SIGNED = new SignatureStatus("SIGNED");
+
+    /**
+     * The job has reached a state where the status of this signature is not applicable.
+     * This includes the case where a signer rejects to sign, and thus ending the job in a
+     * {@link PortalJobStatus#FAILED} state. Any remaining (previously {@link #WAITING})
+     * signatures are marked as {@link #NOT_APPLICABLE}.
+     */
+    public static final SignatureStatus NOT_APPLICABLE = new SignatureStatus("NOT_APPLICABLE");
+
 
     private static final List<SignatureStatus> KNOWN_STATUSES = asList(
             REJECTED,
@@ -37,7 +76,8 @@ public final class SignatureStatus {
             CONTACT_INFORMATION_MISSING,
             EXPIRED,
             WAITING,
-            SIGNED
+            SIGNED,
+            NOT_APPLICABLE
     );
 
     private final String identifier;


### PR DESCRIPTION
Brukes i tilfeller hvor en signatar "stopper" en flersignatarjobb, og
resterende signaturer ikke vil bli utført og har noen betydning. De får
typisk endret status fra WAITING til NOT_APPLICABLE.

Lagt til litt javadoc på hver SignatureStatus. Hva tror dokumentasjonskongen @lillesand om dette?

Ikke merge enda, har bare opprettet PR på tidlig tidspunkt.