### PR TITLE
Polling for synkrone oppdrag

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <name>Posten signering - Java API Client Library</name>
     <groupId>no.digipost.signature</groupId>
     <artifactId>signature-api-client-java</artifactId>
-    <version>1.1-SNAPSHOT</version>
+    <version>1.1-DIRECT-POLLING-SNAPSHOT</version>
 
     <parent>
         <groupId>no.digipost</groupId>
@@ -16,7 +16,7 @@
     <properties>
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
-        <signature.api.version>1.1-SNAPSHOT</signature.api.version>
+        <signature.api.version>1.1-DIRECT-POLLING-SNAPSHOT</signature.api.version>
         <spring.version>4.2.5.RELEASE</spring.version>
         <jersey.version>2.22.2</jersey.version>
         <slf4j.version>1.7.18</slf4j.version>

--- a/src/main/java/no/digipost/signature/client/direct/DirectClient.java
+++ b/src/main/java/no/digipost/signature/client/direct/DirectClient.java
@@ -24,12 +24,15 @@ import no.digipost.signature.client.asice.DocumentBundle;
 import no.digipost.signature.client.asice.manifest.CreateDirectManifest;
 import no.digipost.signature.client.core.ConfirmationReference;
 import no.digipost.signature.client.core.PAdESReference;
+import no.digipost.signature.client.core.Sender;
 import no.digipost.signature.client.core.XAdESReference;
 import no.digipost.signature.client.core.internal.ClientHelper;
 import no.digipost.signature.client.core.internal.http.SignatureHttpClientFactory;
+import no.motif.Singular;
 
 import java.io.InputStream;
 
+import static no.digipost.signature.client.direct.DirectJobStatusResponse.NO_UPDATED_STATUS;
 import static no.digipost.signature.client.direct.JaxbEntityMapping.fromJaxb;
 import static no.digipost.signature.client.direct.JaxbEntityMapping.toJaxb;
 
@@ -65,6 +68,15 @@ public class DirectClient {
     public DirectJobStatusResponse getStatus(StatusReference statusReference) {
         XMLDirectSignatureJobStatusResponse xmlSignatureJobStatusResponse = client.sendSignatureJobStatusRequest(statusReference.getStatusUrl());
         return fromJaxb(xmlSignatureJobStatusResponse);
+    }
+
+    public DirectJobStatusResponse getStatusChange() {
+        return getStatusChange(null);
+    }
+
+    public DirectJobStatusResponse getStatusChange(Sender sender) {
+        XMLDirectSignatureJobStatusResponse statusChange = client.getDirectStatusChange(Singular.optional(sender));
+        return statusChange == null ? NO_UPDATED_STATUS : fromJaxb(statusChange);
     }
 
 

--- a/src/main/java/no/digipost/signature/client/direct/DirectClient.java
+++ b/src/main/java/no/digipost/signature/client/direct/DirectClient.java
@@ -70,10 +70,38 @@ public class DirectClient {
         return fromJaxb(xmlSignatureJobStatusResponse);
     }
 
+    /**
+     * If there is a job with an updated {@link DirectJobStatus status}, the returned object contains
+     * necessary information to act on the status change. The returned object can be queried using
+     * {@link DirectJobStatusResponse#is(DirectJobStatus) .is(}{@link DirectJobStatus#NO_CHANGES NO_CHANGES)}
+     * to determine if there has been a status change. When processing of the status change is complete, (e.g. retrieving
+     * {@link #getPAdES(PAdESReference) PAdES} and/or {@link #getXAdES(XAdESReference) XAdES} documents for a
+     * {@link DirectJobStatus#SIGNED signed} job, the returned status must be {@link #confirm(DirectJobStatusResponse) confirmed}.
+     * <p>
+     * Only jobs with {@link DirectJob.Builder#retrieveStatusBy(StatusRetrievalMethod) status retrieval method} set
+     * to {@link StatusRetrievalMethod#POLLING POLLING} will be returned.
+     *
+     * @return the changed status for a job, or {@link DirectJobStatusResponse#NO_UPDATED_STATUS NO_UPDATED_STATUS},
+     *         never {@code null}.
+     */
     public DirectJobStatusResponse getStatusChange() {
         return getStatusChange(null);
     }
 
+    /**
+     * If there is a job with an updated {@link DirectJobStatus status}, the returned object contains
+     * necessary information to act on the status change. The returned object can be queried using
+     * {@link DirectJobStatusResponse#is(DirectJobStatus) .is(}{@link DirectJobStatus#NO_CHANGES NO_CHANGES)}
+     * to determine if there has been a status change. When processing of the status change is complete, (e.g. retrieving
+     * {@link #getPAdES(PAdESReference) PAdES} and/or {@link #getXAdES(XAdESReference) XAdES} documents for a
+     * {@link DirectJobStatus#SIGNED signed} job, the returned status must be {@link #confirm(DirectJobStatusResponse) confirmed}.
+     * <p>
+     * Only jobs with {@link DirectJob.Builder#retrieveStatusBy(StatusRetrievalMethod) status retrieval method} set
+     * to {@link StatusRetrievalMethod#POLLING POLLING} will be returned.
+     *
+     * @return the changed status for a job, or {@link DirectJobStatusResponse#NO_UPDATED_STATUS NO_UPDATED_STATUS},
+     *         never {@code null}.
+     */
     public DirectJobStatusResponse getStatusChange(Sender sender) {
         XMLDirectSignatureJobStatusResponse statusChange = client.getDirectStatusChange(Singular.optional(sender));
         return statusChange == null ? NO_UPDATED_STATUS : fromJaxb(statusChange);
@@ -81,12 +109,16 @@ public class DirectClient {
 
 
     /**
-     * Confirms that the status retrieved from {@link #getStatus(StatusReference)} is received.
+     * Confirms that the status retrieved from {@link #getStatus(StatusReference)} or {@link #getStatusChange()} is received.
      * If the confirmed {@link DirectJobStatus} is a terminal status
      * (e.g. {@link DirectJobStatus#SIGNED signed} or {@link DirectJobStatus#REJECTED rejected}),
      * the Signature service may make the job's associated resources unavailable through the API when
      * receiving the confirmation. Calling this method for a response with no {@link ConfirmationReference}
      * has no effect.
+     * <p>
+     * If the status is retrieved using {@link #getStatusChange() the polling method}, failing to confirm the
+     * received response may cause subsequent statuses for the same job to be reported as "changed", even
+     * though the status has not changed.
      *
      * @param receivedStatusResponse the updated status retrieved from {@link #getStatus(StatusReference)}.
      */

--- a/src/main/java/no/digipost/signature/client/direct/DirectJob.java
+++ b/src/main/java/no/digipost/signature/client/direct/DirectJob.java
@@ -23,6 +23,8 @@ import no.motif.single.Optional;
 
 import java.util.UUID;
 
+import static no.digipost.signature.client.direct.StatusRetrievalMethod.WAIT_FOR_CALLBACK;
+
 public class DirectJob implements SignatureJob, WithExitUrls {
 
     private String reference;
@@ -32,6 +34,7 @@ public class DirectJob implements SignatureJob, WithExitUrls {
     private String rejectionUrl;
     private String errorUrl;
     private Optional<Sender> sender = Singular.none();
+    private StatusRetrievalMethod statusRetrievalMethod = WAIT_FOR_CALLBACK;
 
     private DirectJob(DirectSigner signer, DirectDocument document, String completionUrl, String rejectionUrl, String errorUrl) {
         this.signer = signer;
@@ -75,6 +78,10 @@ public class DirectJob implements SignatureJob, WithExitUrls {
         return errorUrl;
     }
 
+    public StatusRetrievalMethod getStatusRetrievalMethod() {
+        return statusRetrievalMethod;
+    }
+
     /**
      * Create a new DirectJob.
      *
@@ -116,6 +123,11 @@ public class DirectJob implements SignatureJob, WithExitUrls {
          */
         public Builder withSender(Sender sender) {
             target.sender = Singular.optional(sender);
+            return this;
+        }
+
+        public Builder retrieveStatusBy(StatusRetrievalMethod statusRetrievalMethod) {
+            target.statusRetrievalMethod = statusRetrievalMethod;
             return this;
         }
 

--- a/src/main/java/no/digipost/signature/client/direct/DirectJobStatus.java
+++ b/src/main/java/no/digipost/signature/client/direct/DirectJobStatus.java
@@ -38,7 +38,12 @@ public enum DirectJobStatus {
      *
      * @see XMLDirectSignatureJobStatus#FAILED
      */
-    FAILED;
+    FAILED,
+
+    /**
+     * There has not been any changes since the last received status change.
+     */
+    NO_CHANGES;
 
     public static DirectJobStatus fromXmlType(XMLDirectSignatureJobStatus xmlJobStatus) {
         switch (xmlJobStatus) {

--- a/src/main/java/no/digipost/signature/client/direct/DirectJobStatus.java
+++ b/src/main/java/no/digipost/signature/client/direct/DirectJobStatus.java
@@ -15,43 +15,86 @@
  */
 package no.digipost.signature.client.direct;
 
-import no.digipost.signature.api.xml.XMLDirectSignatureJobStatus;
+import java.util.List;
+import java.util.Objects;
 
-public enum DirectJobStatus {
+import static java.util.Arrays.asList;
+
+public final class DirectJobStatus {
 
     /**
-     * The document(s) of the job has been signed by the receiver.
-     *
-     * @see XMLDirectSignatureJobStatus#SIGNED
+     * The user decided to reject to sign the document, and has been redirected to the
+     * rejection-url provided in the direct-signature-job-request's exit-urls.
      */
-    SIGNED,
+    public static final DirectJobStatus REJECTED = new DirectJobStatus("REJECTED");
 
     /**
-     * The signature job has been rejected by the receiver.
-     *
-     * @see XMLDirectSignatureJobStatus#REJECTED
+     * The user didn't sign the document before the job expired.
      */
-    REJECTED,
+    public static final DirectJobStatus EXPIRED = new DirectJobStatus("EXPIRED");
 
     /**
-     * An error occured during the signing ceremony.
-     *
-     * @see XMLDirectSignatureJobStatus#FAILED
+     * The document has been signed, and the signer has been redirected to the
+     * completion-url provided in the direct-signature-job-request's exit-urls.
+     * The signed document artifacts can be downloaded by following the appropriate
+     * urls in the direct-signature-job-status-response.
      */
-    FAILED,
+    public static final DirectJobStatus SIGNED = new DirectJobStatus("SIGNED");
 
     /**
+     * An unexpected error occured during the signing ceremony, and the user has been redirected to the
+     * error-url provided in the direct-signature-job-request's exit-urls.
+     */
+    public static final DirectJobStatus FAILED = new DirectJobStatus("FAILED");
+
+	/**
      * There has not been any changes since the last received status change.
      */
-    NO_CHANGES;
+    public static final DirectJobStatus NO_CHANGES = new DirectJobStatus("NO_CHANGES");
 
-    public static DirectJobStatus fromXmlType(XMLDirectSignatureJobStatus xmlJobStatus) {
-        switch (xmlJobStatus) {
-            case SIGNED:   return SIGNED;
-            case REJECTED: return REJECTED;
-            case FAILED:   return FAILED;
-            default:       throw new IllegalArgumentException("Unexpected status: " + xmlJobStatus);
-        }
+    private static final List<DirectJobStatus> KNOWN_STATUSES = asList(
+            REJECTED,
+            EXPIRED,
+            SIGNED,
+            FAILED
+    );
+
+    private final String identifier;
+
+    public DirectJobStatus(String identifier) {
+        this.identifier = identifier;
     }
 
+    public static DirectJobStatus fromXmlType(String xmlDirectJobStatus) {
+        for (DirectJobStatus status : KNOWN_STATUSES) {
+            if (status.is(xmlDirectJobStatus)) {
+                return status;
+            }
+        }
+
+        return new DirectJobStatus(xmlDirectJobStatus);
+    }
+
+    private boolean is(String xmlDirectJobStatus) {
+        return this.identifier.equals(xmlDirectJobStatus);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o instanceof DirectJobStatus) {
+            DirectJobStatus that = (DirectJobStatus) o;
+            return Objects.equals(identifier, that.identifier);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(identifier);
+    }
+
+    @Override
+    public String toString() {
+        return identifier;
+    }
 }

--- a/src/main/java/no/digipost/signature/client/direct/DirectJobStatusResponse.java
+++ b/src/main/java/no/digipost/signature/client/direct/DirectJobStatusResponse.java
@@ -20,16 +20,38 @@ import no.digipost.signature.client.core.PAdESReference;
 import no.digipost.signature.client.core.XAdESReference;
 import no.digipost.signature.client.core.internal.Confirmable;
 
+import static no.digipost.signature.client.direct.DirectJobStatus.NO_CHANGES;
+
 
 public class DirectJobStatusResponse implements Confirmable {
 
-    private final long signatureJobId;
+    /**
+     * This instance indicates that there has been no status updates since the last poll request for
+     * {@link DirectJobStatusResponse}. Its status is {@link DirectJobStatus#NO_CHANGES NO_CHANGES}.
+     */
+    public static final DirectJobStatusResponse NO_UPDATED_STATUS = new DirectJobStatusResponse(null, NO_CHANGES, null, null, null) {
+        @Override
+        public long getSignatureJobId() {
+            throw new IllegalStateException(
+                    "There were " + this + ", and querying the job ID is a programming error. " +
+                            "Use the method is(" + DirectJobStatusResponse.class.getSimpleName() + "." + NO_CHANGES.name() + ") " +
+                            "to check if there were any status change before attempting to get any further information.");
+        };
+
+        @Override
+        public String toString() {
+            return "no direct jobs with updated status";
+        }
+    };
+
+
+    private final Long signatureJobId;
     private final DirectJobStatus status;
     private final ConfirmationReference confirmationReference;
     private final XAdESReference xAdESReference;
     private final PAdESReference pAdESReference;
 
-    public DirectJobStatusResponse(long signatureJobId, DirectJobStatus status, ConfirmationReference confirmationUrl, XAdESReference xAdESReference, PAdESReference pAdESReference) {
+    public DirectJobStatusResponse(Long signatureJobId, DirectJobStatus status, ConfirmationReference confirmationUrl, XAdESReference xAdESReference, PAdESReference pAdESReference) {
         this.signatureJobId = signatureJobId;
         this.status = status;
         this.confirmationReference = confirmationUrl;

--- a/src/main/java/no/digipost/signature/client/direct/DirectJobStatusResponse.java
+++ b/src/main/java/no/digipost/signature/client/direct/DirectJobStatusResponse.java
@@ -34,7 +34,7 @@ public class DirectJobStatusResponse implements Confirmable {
         public long getSignatureJobId() {
             throw new IllegalStateException(
                     "There were " + this + ", and querying the job ID is a programming error. " +
-                            "Use the method is(" + DirectJobStatusResponse.class.getSimpleName() + "." + NO_CHANGES.name() + ") " +
+                            "Use the method is(" + DirectJobStatusResponse.class.getSimpleName() + "." + NO_CHANGES + ") " +
                             "to check if there were any status change before attempting to get any further information.");
         };
 

--- a/src/main/java/no/digipost/signature/client/direct/JaxbEntityMapping.java
+++ b/src/main/java/no/digipost/signature/client/direct/JaxbEntityMapping.java
@@ -32,7 +32,8 @@ final class JaxbEntityMapping {
                         .withCompletionUrl(signatureJob.getCompletionUrl())
                         .withRejectionUrl(signatureJob.getRejectionUrl())
                         .withErrorUrl(signatureJob.getErrorUrl())
-                );
+                )
+                .withStatusRetrievalMethod(signatureJob.getStatusRetrievalMethod().xmlValue);
     }
 
     static DirectJobResponse fromJaxb(XMLDirectSignatureJobResponse xmlSignatureJobResponse) {

--- a/src/main/java/no/digipost/signature/client/direct/StatusRetrievalMethod.java
+++ b/src/main/java/no/digipost/signature/client/direct/StatusRetrievalMethod.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (C) Posten Norge AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.signature.client.direct;
+
+import no.digipost.signature.api.xml.XMLStatusRetrievalMethod;
+
+public enum StatusRetrievalMethod {
+
+    WAIT_FOR_CALLBACK(XMLStatusRetrievalMethod.WAIT_FOR_CALLBACK),
+    POLLING(XMLStatusRetrievalMethod.POLLING);
+
+    public final XMLStatusRetrievalMethod xmlValue;
+
+    StatusRetrievalMethod(XMLStatusRetrievalMethod xmlValue) {
+        this.xmlValue = xmlValue;
+    }
+}

--- a/src/main/java/no/digipost/signature/client/portal/PortalClient.java
+++ b/src/main/java/no/digipost/signature/client/portal/PortalClient.java
@@ -29,6 +29,7 @@ import no.digipost.signature.client.core.XAdESReference;
 import no.digipost.signature.client.core.internal.Cancellable;
 import no.digipost.signature.client.core.internal.ClientHelper;
 import no.digipost.signature.client.core.internal.http.SignatureHttpClientFactory;
+import no.motif.Singular;
 
 import java.io.InputStream;
 
@@ -69,8 +70,7 @@ public class PortalClient {
      *         never {@code null}.
      */
     public PortalJobStatusChanged getStatusChange() {
-        XMLPortalSignatureJobStatusChangeResponse statusChange = client.getStatusChange();
-        return statusChange == null ? NO_UPDATED_STATUS : JaxbEntityMapping.fromJaxb(statusChange);
+        return getStatusChange(null);
     }
 
     /**
@@ -87,7 +87,7 @@ public class PortalClient {
      */
 
     public PortalJobStatusChanged getStatusChange(Sender sender) {
-        XMLPortalSignatureJobStatusChangeResponse statusChange = client.getStatusChange(sender);
+        XMLPortalSignatureJobStatusChangeResponse statusChange = client.getPortalStatusChange(Singular.optional(sender));
         return statusChange == null ? NO_UPDATED_STATUS : JaxbEntityMapping.fromJaxb(statusChange);
     }
 

--- a/src/test/java/no/digipost/signature/client/core/internal/xml/MarshallingTest.java
+++ b/src/test/java/no/digipost/signature/client/core/internal/xml/MarshallingTest.java
@@ -46,7 +46,7 @@ public class MarshallingTest {
                 .withRejectionUrl("http://localhost/rejected")
                 .withErrorUrl("http://localhost/failed");
 
-        XMLDirectSignatureJobRequest directJob = new XMLDirectSignatureJobRequest("123abc", exitUrls);
+        XMLDirectSignatureJobRequest directJob = new XMLDirectSignatureJobRequest("123abc", exitUrls, null);
         XMLDirectSignatureJobManifest directManifest = new XMLDirectSignatureJobManifest(directSigner, sender, directDocument);
 
         marshaller.marshal(directJob, new StreamResult(new ByteArrayOutputStream()));
@@ -65,7 +65,7 @@ public class MarshallingTest {
                 .withRejectionUrl("http://localhost/rejected")
                 .withErrorUrl("http://localhost/failed");
 
-        XMLDirectSignatureJobRequest signatureJobRequest = new XMLDirectSignatureJobRequest("123abc", exitUrls);
+        XMLDirectSignatureJobRequest signatureJobRequest = new XMLDirectSignatureJobRequest("123abc", exitUrls, null);
 
         try {
             marshaller.marshal(signatureJobRequest, new StreamResult(new ByteArrayOutputStream()));

--- a/src/test/java/no/digipost/signature/client/direct/DirectJobStatusTest.java
+++ b/src/test/java/no/digipost/signature/client/direct/DirectJobStatusTest.java
@@ -15,23 +15,15 @@
  */
 package no.digipost.signature.client.direct;
 
-import no.digipost.signature.api.xml.XMLDirectSignatureJobStatus;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import no.digipost.signature.client.portal.SignatureStatus;
 import org.junit.Test;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertThat;
 
 public class DirectJobStatusTest {
 
     @Test
-    public void ableToConvertAllStatusesFromXsd() {
-        List<DirectJobStatus> convertedStatuses = new ArrayList<>();
-        for (XMLDirectSignatureJobStatus xmlStatus : XMLDirectSignatureJobStatus.values()) {
-            convertedStatuses.add(DirectJobStatus.fromXmlType(xmlStatus));
-        }
-        assertThat(convertedStatuses, hasSize(XMLDirectSignatureJobStatus.values().length));
+    public void equals_and_hashCode() {
+        EqualsVerifier.forClass(DirectJobStatus.class).verify();
     }
+
 }


### PR DESCRIPTION
Metoder i `DirectClient` for å spørre tjenesten om noen av virksomhetens signeringsoppdrag har endret status.

Se også https://github.com/digipost/signature-api-specification/pull/42