### PR TITLE
Fjerner XSD-validering på responser fra backend

### DIFF
--- a/src/main/java/no/digipost/signature/client/asice/manifest/ManifestCreator.java
+++ b/src/main/java/no/digipost/signature/client/asice/manifest/ManifestCreator.java
@@ -19,24 +19,21 @@ import no.digipost.signature.client.core.Sender;
 import no.digipost.signature.client.core.SignatureJob;
 import no.digipost.signature.client.core.exceptions.RuntimeIOException;
 import no.digipost.signature.client.core.exceptions.XmlValidationException;
-import no.digipost.signature.client.core.internal.xml.Marshalling;
 import org.springframework.oxm.MarshallingFailureException;
-import org.springframework.oxm.jaxb.Jaxb2Marshaller;
 import org.xml.sax.SAXParseException;
 
-import javax.xml.transform.stream.StreamResult;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
-public abstract class ManifestCreator<JOB extends SignatureJob> {
+import static no.digipost.signature.client.core.internal.xml.Marshalling.marshal;
 
-    private static final Jaxb2Marshaller marshaller = Marshalling.instance();
+public abstract class ManifestCreator<JOB extends SignatureJob> {
 
     public Manifest createManifest(JOB job, Sender sender) {
         Object xmlManifest = buildXmlManifest(job, sender);
 
         try (ByteArrayOutputStream manifestStream = new ByteArrayOutputStream()) {
-            marshaller.marshal(xmlManifest, new StreamResult(manifestStream));
+            marshal(xmlManifest, manifestStream);
             return new Manifest(manifestStream.toByteArray());
         } catch (MarshallingFailureException e) {
             if (e.getMostSpecificCause() instanceof SAXParseException) {

--- a/src/main/java/no/digipost/signature/client/core/internal/xml/JaxbMessageReaderWriterProvider.java
+++ b/src/main/java/no/digipost/signature/client/core/internal/xml/JaxbMessageReaderWriterProvider.java
@@ -16,7 +16,6 @@
 package no.digipost.signature.client.core.internal.xml;
 
 import org.glassfish.jersey.message.internal.AbstractMessageReaderWriterProvider;
-import org.springframework.oxm.jaxb.Jaxb2Marshaller;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.Produces;
@@ -24,24 +23,19 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.ext.Provider;
-import javax.xml.transform.stream.StreamResult;
-import javax.xml.transform.stream.StreamSource;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 
+import static no.digipost.signature.client.core.internal.xml.Marshalling.marshal;
+import static no.digipost.signature.client.core.internal.xml.Marshalling.unmarshal;
+
 @Provider
 @Produces(MediaType.APPLICATION_XML)
 @Consumes(MediaType.APPLICATION_XML)
 public class JaxbMessageReaderWriterProvider extends AbstractMessageReaderWriterProvider<Object> {
-
-    private final Jaxb2Marshaller marshaller;
-
-    public JaxbMessageReaderWriterProvider() {
-        marshaller = Marshalling.instance();
-    }
 
     @Override
     public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
@@ -50,7 +44,7 @@ public class JaxbMessageReaderWriterProvider extends AbstractMessageReaderWriter
 
     @Override
     public Object readFrom(Class<Object> type, Type genericType, Annotation[] annotations, MediaType mediaType, MultivaluedMap<String, String> httpHeaders, InputStream entityStream) throws IOException, WebApplicationException {
-        return marshaller.unmarshal(new StreamSource(entityStream));
+        return unmarshal(entityStream);
     }
 
     @Override
@@ -60,6 +54,6 @@ public class JaxbMessageReaderWriterProvider extends AbstractMessageReaderWriter
 
     @Override
     public void writeTo(Object o, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType, MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException, WebApplicationException {
-        marshaller.marshal(o, new StreamResult(entityStream));
+        marshal(o, entityStream);
     }
 }

--- a/src/test/java/no/digipost/signature/client/asice/signature/CreateSignatureTest.java
+++ b/src/test/java/no/digipost/signature/client/asice/signature/CreateSignatureTest.java
@@ -15,21 +15,19 @@
  */
 package no.digipost.signature.client.asice.signature;
 
-import no.digipost.signature.client.TestKonfigurasjon;
-import no.digipost.signature.client.asice.ASiCEAttachable;
-import no.digipost.signature.client.core.internal.xml.Marshalling;
-import no.digipost.signature.client.security.KeyStoreConfig;
 import no.digipost.signature.api.xml.thirdparty.asice.XAdESSignatures;
 import no.digipost.signature.api.xml.thirdparty.xades.*;
 import no.digipost.signature.api.xml.thirdparty.xmldsig.Reference;
 import no.digipost.signature.api.xml.thirdparty.xmldsig.SignedInfo;
 import no.digipost.signature.api.xml.thirdparty.xmldsig.X509IssuerSerialType;
+import no.digipost.signature.client.TestKonfigurasjon;
+import no.digipost.signature.client.asice.ASiCEAttachable;
+import no.digipost.signature.client.security.KeyStoreConfig;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.oxm.jaxb.Jaxb2Marshaller;
 
 import javax.xml.transform.stream.StreamSource;
-
 import java.io.ByteArrayInputStream;
 import java.math.BigInteger;
 import java.util.List;
@@ -51,7 +49,10 @@ public class CreateSignatureTest {
     private KeyStoreConfig noekkelpar;
     private List<ASiCEAttachable> files;
 
-    private static final Jaxb2Marshaller marshaller = Marshalling.instance();
+    private static final Jaxb2Marshaller marshaller; static {
+        marshaller = new Jaxb2Marshaller();
+        marshaller.setClassesToBeBound(XAdESSignatures.class, QualifyingProperties.class);
+    }
 
     @Before
     public void setUp() throws Exception {

--- a/src/test/java/no/digipost/signature/client/core/internal/xml/MarshallingTest.java
+++ b/src/test/java/no/digipost/signature/client/core/internal/xml/MarshallingTest.java
@@ -18,21 +18,17 @@ package no.digipost.signature.client.core.internal.xml;
 import no.digipost.signature.api.xml.*;
 import org.junit.Test;
 import org.springframework.oxm.MarshallingFailureException;
-import org.springframework.oxm.jaxb.Jaxb2Marshaller;
-
-import javax.xml.transform.stream.StreamResult;
 
 import java.io.ByteArrayOutputStream;
 import java.util.Date;
 
+import static no.digipost.signature.client.core.internal.xml.Marshalling.marshal;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 public class MarshallingTest {
-
-    private final Jaxb2Marshaller marshaller = Marshalling.instance();
 
     @Test
     public void valid_objects_can_be_marshalled() {
@@ -49,13 +45,13 @@ public class MarshallingTest {
         XMLDirectSignatureJobRequest directJob = new XMLDirectSignatureJobRequest("123abc", exitUrls, null);
         XMLDirectSignatureJobManifest directManifest = new XMLDirectSignatureJobManifest(directSigner, sender, directDocument);
 
-        marshaller.marshal(directJob, new StreamResult(new ByteArrayOutputStream()));
-        marshaller.marshal(directManifest, new StreamResult(new ByteArrayOutputStream()));
+        marshal(directJob, new ByteArrayOutputStream());
+        marshal(directManifest, new ByteArrayOutputStream());
 
         XMLPortalSignatureJobRequest portalJob = new XMLPortalSignatureJobRequest("123abc");
         XMLPortalSignatureJobManifest portalManifest = new XMLPortalSignatureJobManifest(new XMLPortalSigners().withSigners(portalSigner), sender, portalDocument, new XMLAvailability().withActivationTime(new Date()));
-        marshaller.marshal(portalJob, new StreamResult(new ByteArrayOutputStream()));
-        marshaller.marshal(portalManifest, new StreamResult(new ByteArrayOutputStream()));
+        marshal(portalJob, new ByteArrayOutputStream());
+        marshal(portalManifest, new ByteArrayOutputStream());
     }
 
     @Test
@@ -68,7 +64,7 @@ public class MarshallingTest {
         XMLDirectSignatureJobRequest signatureJobRequest = new XMLDirectSignatureJobRequest("123abc", exitUrls, null);
 
         try {
-            marshaller.marshal(signatureJobRequest, new StreamResult(new ByteArrayOutputStream()));
+            marshal(signatureJobRequest, new ByteArrayOutputStream());
             fail("Should have failed with XSD-validation error due to completion-url being empty.");
         } catch (MarshallingFailureException e) {
             assertThat(e.getMessage(), allOf(containsString("completion-url"), containsString("is expected")));
@@ -87,8 +83,8 @@ public class MarshallingTest {
         XMLPortalSignatureJobManifest portalManifest = new XMLPortalSignatureJobManifest(new XMLPortalSigners().withSigners(portalSigner), sender, portalDocument, null);
 
         try {
-            marshaller.marshal(directManifest, new StreamResult(new ByteArrayOutputStream()));
-            marshaller.marshal(portalManifest, new StreamResult(new ByteArrayOutputStream()));
+            marshal(directManifest, new ByteArrayOutputStream());
+            marshal(portalManifest, new ByteArrayOutputStream());
             fail("Should have failed with XSD-validation error due to href-attribute on document element being empty.");
         } catch (MarshallingFailureException e) {
             assertThat(e.getMessage(), allOf(containsString("href"), containsString("must appear")));

--- a/src/test/java/no/digipost/signature/client/core/internal/xml/MarshallingTest.java
+++ b/src/test/java/no/digipost/signature/client/core/internal/xml/MarshallingTest.java
@@ -22,7 +22,9 @@ import org.springframework.oxm.MarshallingFailureException;
 import java.io.ByteArrayOutputStream;
 import java.util.Date;
 
+import static junit.framework.TestCase.assertEquals;
 import static no.digipost.signature.client.core.internal.xml.Marshalling.marshal;
+import static no.digipost.signature.client.core.internal.xml.Marshalling.unmarshal;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertThat;
@@ -89,6 +91,14 @@ public class MarshallingTest {
         } catch (MarshallingFailureException e) {
             assertThat(e.getMessage(), allOf(containsString("href"), containsString("must appear")));
         }
+    }
+
+    @Test
+    public void ignores_unexpected_elements_in_response() {
+        XMLDirectSignatureJobStatusResponse unmarshalled = (XMLDirectSignatureJobStatusResponse) unmarshal(this.getClass().getResourceAsStream("/xml/direct_signature_job_response_with_unexpected_element.xml"));
+
+        assertEquals(1, unmarshalled.getSignatureJobId());
+        assertEquals("SIGNED", unmarshalled.getStatus().name());
     }
 
 }

--- a/src/test/resources/xml/direct_signature_job_response_with_unexpected_element.xml
+++ b/src/test/resources/xml/direct_signature_job_response_with_unexpected_element.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<direct-signature-job-status-response xmlns="http://signering.posten.no/schema/v1">
+    <signature-job-id unexpected-element="surprise">1</signature-job-id>
+    <signature-job-status>COMPLETED_SUCCESSFULLY</signature-job-status>
+    <status signer="12345678910">SIGNED</status>
+    <confirmation-url>https://api.signering.posten.no/api/{sender-identifier}/direct/signature-jobs/1/complete</confirmation-url>
+    <xades-url signer="12345678910">https://api.signering.posten.no/api/{sender-identifier}/direct/signature-jobs/1/xades/1</xades-url>
+    <pades-url>https://api.signering.posten.no/api/{sender-identifier}/direct/signature-jobs/1/pades</pades-url>
+</direct-signature-job-status-response>


### PR DESCRIPTION
Klienten bør ikke validere responser fordi det forhindrer oss fra å gjøre endringer som ikke brekker bakoverkompatibiliteten.