### PR TITLE
Støtte for opptil 10 signatarer for synkrone oppdrag

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <name>Posten signering - Java API Client Library</name>
     <groupId>no.digipost.signature</groupId>
     <artifactId>signature-api-client-java</artifactId>
-    <version>1.3-MULTIPLE-SIGNERS-DIRECT-SNAPSHOT</version>
+    <version>1.3-SNAPSHOT</version>
 
     <parent>
         <groupId>no.digipost</groupId>
@@ -16,7 +16,7 @@
     <properties>
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
-        <signature.api.version>1.3-MULTIPLE-SIGNERS-DIRECT-SNAPSHOT</signature.api.version>
+        <signature.api.version>1.3-SNAPSHOT</signature.api.version>
         <spring.version>4.2.5.RELEASE</spring.version>
         <jersey.version>2.22.2</jersey.version>
         <slf4j.version>1.7.18</slf4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <name>Posten signering - Java API Client Library</name>
     <groupId>no.digipost.signature</groupId>
     <artifactId>signature-api-client-java</artifactId>
-    <version>1.3-SNAPSHOT</version>
+    <version>1.3-MULTIPLE-SIGNERS-DIRECT-SNAPSHOT</version>
 
     <parent>
         <groupId>no.digipost</groupId>
@@ -16,7 +16,7 @@
     <properties>
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
-        <signature.api.version>1.2</signature.api.version>
+        <signature.api.version>1.3-MULTIPLE-SIGNERS-DIRECT-SNAPSHOT</signature.api.version>
         <spring.version>4.2.5.RELEASE</spring.version>
         <jersey.version>2.22.2</jersey.version>
         <slf4j.version>1.7.18</slf4j.version>

--- a/src/main/java/no/digipost/signature/client/asice/manifest/CreateDirectManifest.java
+++ b/src/main/java/no/digipost/signature/client/asice/manifest/CreateDirectManifest.java
@@ -22,6 +22,10 @@ import no.digipost.signature.api.xml.XMLSender;
 import no.digipost.signature.client.core.Sender;
 import no.digipost.signature.client.direct.DirectDocument;
 import no.digipost.signature.client.direct.DirectJob;
+import no.digipost.signature.client.direct.DirectSigner;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class CreateDirectManifest extends ManifestCreator<DirectJob> {
 
@@ -29,8 +33,13 @@ public class CreateDirectManifest extends ManifestCreator<DirectJob> {
     Object buildXmlManifest(DirectJob job, Sender sender) {
         DirectDocument document = job.getDocument();
 
+        List<XMLDirectSigner> signers = new ArrayList<>();
+        for (DirectSigner signer : job.getSigners()) {
+            signers.add(new XMLDirectSigner().withPersonalIdentificationNumber(signer.getPersonalIdentificationNumber()));
+        }
+
         return new XMLDirectSignatureJobManifest()
-                .withSigner(new XMLDirectSigner().withPersonalIdentificationNumber(job.getSigner().getPersonalIdentificationNumber()))
+                .withSigners(signers)
                 .withSender(new XMLSender().withOrganizationNumber(sender.getOrganizationNumber()))
                 .withDocument(new XMLDirectDocument()
                         .withTitle(document.getTitle())

--- a/src/main/java/no/digipost/signature/client/core/XAdESReference.java
+++ b/src/main/java/no/digipost/signature/client/core/XAdESReference.java
@@ -15,17 +15,10 @@
  */
 package no.digipost.signature.client.core;
 
-import no.motif.Singular;
-import no.motif.single.Optional;
-
 public class XAdESReference {
 
     public static XAdESReference of(String url) {
-        return of(Singular.optional(url));
-    }
-
-    public static XAdESReference of(Optional<String> url) {
-        return url.isSome() ? new XAdESReference(url.get()) : null;
+        return url == null ? null : new XAdESReference(url);
     }
 
     private final String xAdESUrl;

--- a/src/main/java/no/digipost/signature/client/core/XAdESReference.java
+++ b/src/main/java/no/digipost/signature/client/core/XAdESReference.java
@@ -15,10 +15,17 @@
  */
 package no.digipost.signature.client.core;
 
+import no.motif.Singular;
+import no.motif.single.Optional;
+
 public class XAdESReference {
 
     public static XAdESReference of(String url) {
-        return url == null ? null : new XAdESReference(url);
+        return of(Singular.optional(url));
+    }
+
+    public static XAdESReference of(Optional<String> url) {
+        return url.isSome() ? new XAdESReference(url.get()) : null;
     }
 
     private final String xAdESUrl;

--- a/src/main/java/no/digipost/signature/client/direct/DirectClient.java
+++ b/src/main/java/no/digipost/signature/client/direct/DirectClient.java
@@ -58,7 +58,8 @@ public class DirectClient {
     /**
      * Get the current status for the given {@link StatusReference}, which references the status for a specific job.
      * When processing of the status is complete (e.g. retrieving {@link #getPAdES(PAdESReference) PAdES} and/or
-     * {@link #getXAdES(XAdESReference) XAdES} documents for a {@link DirectJobStatus#SIGNED signed} job),
+     * {@link #getXAdES(XAdESReference) XAdES} documents for a {@link DirectJobStatus#COMPLETED_SUCCESSFULLY completed} job
+     * where all signers have {@link SignerStatus#SIGNED signed} their documents),
      * the returned status must be {@link #confirm(DirectJobStatusResponse) confirmed}.
      *
      * @param statusReference the reference to the status of a specific job.
@@ -76,7 +77,8 @@ public class DirectClient {
      * {@link DirectJobStatusResponse#is(DirectJobStatus) .is(}{@link DirectJobStatus#NO_CHANGES NO_CHANGES)}
      * to determine if there has been a status change. When processing of the status change is complete, (e.g. retrieving
      * {@link #getPAdES(PAdESReference) PAdES} and/or {@link #getXAdES(XAdESReference) XAdES} documents for a
-     * {@link DirectJobStatus#SIGNED signed} job, the returned status must be {@link #confirm(DirectJobStatusResponse) confirmed}.
+     * {@link DirectJobStatus#COMPLETED_SUCCESSFULLY completed} job where all signers have {@link SignerStatus#SIGNED signed} their documents,
+     * the returned status must be {@link #confirm(DirectJobStatusResponse) confirmed}.
      * <p>
      * Only jobs with {@link DirectJob.Builder#retrieveStatusBy(StatusRetrievalMethod) status retrieval method} set
      * to {@link StatusRetrievalMethod#POLLING POLLING} will be returned.
@@ -94,7 +96,8 @@ public class DirectClient {
      * {@link DirectJobStatusResponse#is(DirectJobStatus) .is(}{@link DirectJobStatus#NO_CHANGES NO_CHANGES)}
      * to determine if there has been a status change. When processing of the status change is complete, (e.g. retrieving
      * {@link #getPAdES(PAdESReference) PAdES} and/or {@link #getXAdES(XAdESReference) XAdES} documents for a
-     * {@link DirectJobStatus#SIGNED signed} job, the returned status must be {@link #confirm(DirectJobStatusResponse) confirmed}.
+     * {@link DirectJobStatus#COMPLETED_SUCCESSFULLY completed} job where all signers have {@link SignerStatus#SIGNED signed} their documents,
+     * the returned status must be {@link #confirm(DirectJobStatusResponse) confirmed}.
      * <p>
      * Only jobs with {@link DirectJob.Builder#retrieveStatusBy(StatusRetrievalMethod) status retrieval method} set
      * to {@link StatusRetrievalMethod#POLLING POLLING} will be returned.
@@ -111,7 +114,7 @@ public class DirectClient {
     /**
      * Confirms that the status retrieved from {@link #getStatus(StatusReference)} or {@link #getStatusChange()} is received.
      * If the confirmed {@link DirectJobStatus} is a terminal status
-     * (e.g. {@link DirectJobStatus#SIGNED signed} or {@link DirectJobStatus#REJECTED rejected}),
+     * (i.e. {@link DirectJobStatus#COMPLETED_SUCCESSFULLY completed} or {@link DirectJobStatus#FAILED failed}),
      * the Signature service may make the job's associated resources unavailable through the API when
      * receiving the confirmation. Calling this method for a response with no {@link ConfirmationReference}
      * has no effect.

--- a/src/main/java/no/digipost/signature/client/direct/DirectJob.java
+++ b/src/main/java/no/digipost/signature/client/direct/DirectJob.java
@@ -21,14 +21,15 @@ import no.digipost.signature.client.core.SignatureJob;
 import no.motif.Singular;
 import no.motif.single.Optional;
 
-import java.util.UUID;
+import java.util.*;
 
+import static java.util.Collections.unmodifiableList;
 import static no.digipost.signature.client.direct.StatusRetrievalMethod.WAIT_FOR_CALLBACK;
 
 public class DirectJob implements SignatureJob, WithExitUrls {
 
     private String reference;
-    private DirectSigner signer;
+    private List<DirectSigner> signers;
     private DirectDocument document;
     private String completionUrl;
     private String rejectionUrl;
@@ -36,8 +37,8 @@ public class DirectJob implements SignatureJob, WithExitUrls {
     private Optional<Sender> sender = Singular.none();
     private StatusRetrievalMethod statusRetrievalMethod = WAIT_FOR_CALLBACK;
 
-    private DirectJob(DirectSigner signer, DirectDocument document, String completionUrl, String rejectionUrl, String errorUrl) {
-        this.signer = signer;
+    private DirectJob(List<DirectSigner> signers, DirectDocument document, String completionUrl, String rejectionUrl, String errorUrl) {
+        this.signers = unmodifiableList(new ArrayList<>(signers));
         this.document = document;
         this.completionUrl = completionUrl;
         this.rejectionUrl = rejectionUrl;
@@ -49,8 +50,8 @@ public class DirectJob implements SignatureJob, WithExitUrls {
         return reference;
     }
 
-    public DirectSigner getSigner() {
-        return signer;
+    public List<DirectSigner> getSigners() {
+        return signers;
     }
 
     @Override
@@ -94,17 +95,24 @@ public class DirectJob implements SignatureJob, WithExitUrls {
      * @return a builder to further customize the job
      */
     public static Builder builder(DirectSigner signer, DirectDocument document, WithExitUrls hasExitUrls) {
-        return new Builder(signer, document, hasExitUrls.getCompletionUrl(), hasExitUrls.getRejectionUrl(), hasExitUrls.getErrorUrl());
+        return new Builder(Arrays.asList(signer), document, hasExitUrls.getCompletionUrl(), hasExitUrls.getRejectionUrl(), hasExitUrls.getErrorUrl());
     }
 
+    public static Builder builder(DirectDocument document, WithExitUrls hasExitUrls, DirectSigner... signers) {
+        return builder(document, hasExitUrls, Arrays.asList(signers));
+    }
+
+    public static Builder builder(DirectDocument document, WithExitUrls hasExitUrls, List<DirectSigner> signers) {
+        return new Builder(signers, document, hasExitUrls.getCompletionUrl(), hasExitUrls.getRejectionUrl(), hasExitUrls.getErrorUrl());
+    }
 
     public static class Builder {
 
         private final DirectJob target;
         private boolean built = false;
 
-        public Builder(DirectSigner signer, DirectDocument document, String completionUrl, String rejectionUrl, String errorUrl) {
-            target = new DirectJob(signer, document, completionUrl, rejectionUrl, errorUrl);
+        public Builder(List<DirectSigner> signers, DirectDocument document, String completionUrl, String rejectionUrl, String errorUrl) {
+            target = new DirectJob(signers, document, completionUrl, rejectionUrl, errorUrl);
         }
 
         public Builder withReference(UUID uuid) {

--- a/src/main/java/no/digipost/signature/client/direct/DirectJob.java
+++ b/src/main/java/no/digipost/signature/client/direct/DirectJob.java
@@ -86,22 +86,31 @@ public class DirectJob implements SignatureJob, WithExitUrls {
     /**
      * Create a new DirectJob.
      *
-     * @param signer      The {@link DirectSigner} of the document.
      * @param document    The {@link DirectDocument} that should be signed.
      * @param hasExitUrls specifies the urls the user will be redirected back to upon completing/rejecting/failing
      *                    the signing ceremony. See {@link ExitUrls#of(String, String, String)}, and alternatively
      *                    {@link ExitUrls#singleExitUrl(String)}.
+     * @param signers     The {@link DirectSigner DirectSigners} of the document.
      *
      * @return a builder to further customize the job
+     * @see DirectJob#builder(DirectDocument, WithExitUrls, List)
      */
-    public static Builder builder(DirectSigner signer, DirectDocument document, WithExitUrls hasExitUrls) {
-        return new Builder(Arrays.asList(signer), document, hasExitUrls.getCompletionUrl(), hasExitUrls.getRejectionUrl(), hasExitUrls.getErrorUrl());
-    }
-
     public static Builder builder(DirectDocument document, WithExitUrls hasExitUrls, DirectSigner... signers) {
         return builder(document, hasExitUrls, Arrays.asList(signers));
     }
 
+    /**
+     * Create a new DirectJob.
+     *
+     * @param document    The {@link DirectDocument} that should be signed.
+     * @param hasExitUrls specifies the urls the user will be redirected back to upon completing/rejecting/failing
+     *                    the signing ceremony. See {@link ExitUrls#of(String, String, String)}, and alternatively
+     *                    {@link ExitUrls#singleExitUrl(String)}.
+     * @param signers     The {@link DirectSigner DirectSigners} of the document.
+     *
+     * @return a builder to further customize the job
+     * @see DirectJob#builder(DirectDocument, WithExitUrls, DirectSigner...)
+     */
     public static Builder builder(DirectDocument document, WithExitUrls hasExitUrls, List<DirectSigner> signers) {
         return new Builder(signers, document, hasExitUrls.getCompletionUrl(), hasExitUrls.getRejectionUrl(), hasExitUrls.getErrorUrl());
     }

--- a/src/main/java/no/digipost/signature/client/direct/DirectJobResponse.java
+++ b/src/main/java/no/digipost/signature/client/direct/DirectJobResponse.java
@@ -38,19 +38,10 @@ public class DirectJobResponse {
      * Gets the only redirect URL for this job.
      * Convenience method for retrieving the redirect URL for jobs with exactly one signer.
      * @throws IllegalStateException if there are multiple redirect URLs
-     * @see #getRedirectUrlFor(String)
+     * @see #getRedirectUrls()
      */
-    public String getRedirectUrl() {
+    public String getSingleRedirectUrl() {
         return redirectUrls.getSingleRedirectUrl();
-    }
-
-	/**
-     * Gets the redirect URL for a given signer.
-     * @throws IllegalArgumentException if the job response doesn't contain a redirect URL for this signer
-     * @see #getRedirectUrl()
-     */
-    public String getRedirectUrlFor(String personalIdentificationNumber) {
-        return redirectUrls.getFor(personalIdentificationNumber);
     }
 
     public RedirectUrls getRedirectUrls() {

--- a/src/main/java/no/digipost/signature/client/direct/DirectJobResponse.java
+++ b/src/main/java/no/digipost/signature/client/direct/DirectJobResponse.java
@@ -15,14 +15,18 @@
  */
 package no.digipost.signature.client.direct;
 
-public class DirectJobResponse {
-    private long signatureJobId;
-    private String redirectUrl;
-    private String statusUrl;
+import no.digipost.signature.client.direct.RedirectUrls.RedirectUrl;
 
-    public DirectJobResponse(long signatureJobId, String redirectUrl, String statusUrl) {
+import java.util.List;
+
+public class DirectJobResponse {
+    private final long signatureJobId;
+    private final RedirectUrls redirectUrls;
+    private final String statusUrl;
+
+    public DirectJobResponse(long signatureJobId, List<RedirectUrl> redirectUrls, String statusUrl) {
         this.signatureJobId = signatureJobId;
-        this.redirectUrl = redirectUrl;
+        this.redirectUrls = new RedirectUrls(redirectUrls);
         this.statusUrl = statusUrl;
     }
 
@@ -30,8 +34,27 @@ public class DirectJobResponse {
         return signatureJobId;
     }
 
+	/**
+     * Gets the only redirect URL for this job.
+     * Convenience method for retrieving the redirect URL for jobs with exactly one signer.
+     * @throws IllegalStateException if there are multiple redirect URLs
+     * @see #getRedirectUrlFor(String)
+     */
     public String getRedirectUrl() {
-        return redirectUrl;
+        return redirectUrls.getSingleRedirectUrl();
+    }
+
+	/**
+     * Gets the redirect URL for a given signer.
+     * @throws IllegalArgumentException if the job response doesn't contain a redirect URL for this signer
+     * @see #getRedirectUrl()
+     */
+    public String getRedirectUrlFor(String personalIdentificationNumber) {
+        return redirectUrls.getFor(personalIdentificationNumber);
+    }
+
+    public RedirectUrls getRedirectUrls() {
+        return redirectUrls;
     }
 
     public String getStatusUrl() {

--- a/src/main/java/no/digipost/signature/client/direct/DirectJobStatus.java
+++ b/src/main/java/no/digipost/signature/client/direct/DirectJobStatus.java
@@ -20,31 +20,26 @@ import no.digipost.signature.api.xml.XMLDirectSignatureJobStatus;
 public enum DirectJobStatus {
 
     /**
-     * The document(s) of the job has been signed by the receiver.
+     * At least one signer has not yet performed any action to the document.
+     * For details about the state, see the {@link SignerStatus status} of each signer.
      *
-     * @see XMLDirectSignatureJobStatus#SIGNED
+     * @see XMLDirectSignatureJobStatus#IN_PROGRESS
      */
-    SIGNED,
+    IN_PROGRESS,
 
     /**
-     * The signature job has been rejected by the receiver.
+     * All signers have successfully signed the document.
      *
-     * @see XMLDirectSignatureJobStatus#REJECTED
+     * @see XMLDirectSignatureJobStatus#COMPLETED_SUCCESSFULLY
      */
-    REJECTED,
+    COMPLETED_SUCCESSFULLY,
 
     /**
-     * An error occured during the signing ceremony.
+     * All signers have performed an action to the document, but at least one have a non successful status (e.g. rejected, expired or failed).
      *
      * @see XMLDirectSignatureJobStatus#FAILED
      */
     FAILED,
-    /**
-     * The user didn't sign the document before the job expired.
-     *
-     * @see XMLDirectSignatureJobStatus#EXPIRED
-     */
-    EXPIRED,
 
     /**
      * There has not been any changes since the last received status change.
@@ -53,11 +48,14 @@ public enum DirectJobStatus {
 
     public static DirectJobStatus fromXmlType(XMLDirectSignatureJobStatus xmlJobStatus) {
         switch (xmlJobStatus) {
-            case SIGNED:   return SIGNED;
-            case REJECTED: return REJECTED;
-            case FAILED:   return FAILED;
-            case EXPIRED:  return EXPIRED;
-            default:       throw new IllegalArgumentException("Unexpected status: " + xmlJobStatus);
+            case IN_PROGRESS:
+                return IN_PROGRESS;
+            case COMPLETED_SUCCESSFULLY:
+                return COMPLETED_SUCCESSFULLY;
+            case FAILED:
+                return FAILED;
+            default:
+                throw new IllegalArgumentException("Unexpected status: " + xmlJobStatus);
         }
     }
 

--- a/src/main/java/no/digipost/signature/client/direct/DirectJobStatusResponse.java
+++ b/src/main/java/no/digipost/signature/client/direct/DirectJobStatusResponse.java
@@ -17,8 +17,9 @@ package no.digipost.signature.client.direct;
 
 import no.digipost.signature.client.core.ConfirmationReference;
 import no.digipost.signature.client.core.PAdESReference;
-import no.digipost.signature.client.core.XAdESReference;
 import no.digipost.signature.client.core.internal.Confirmable;
+
+import java.util.List;
 
 import static no.digipost.signature.client.direct.DirectJobStatus.NO_CHANGES;
 
@@ -48,14 +49,14 @@ public class DirectJobStatusResponse implements Confirmable {
     private final Long signatureJobId;
     private final DirectJobStatus status;
     private final ConfirmationReference confirmationReference;
-    private final XAdESReference xAdESReference;
+    private final List<Signature> signatures;
     private final PAdESReference pAdESReference;
 
-    public DirectJobStatusResponse(Long signatureJobId, DirectJobStatus status, ConfirmationReference confirmationUrl, XAdESReference xAdESReference, PAdESReference pAdESReference) {
+    public DirectJobStatusResponse(Long signatureJobId, DirectJobStatus signatureJobStatus, ConfirmationReference confirmationUrl, List<Signature> signatures, PAdESReference pAdESReference) {
         this.signatureJobId = signatureJobId;
-        this.status = status;
+        this.status = signatureJobStatus;
         this.confirmationReference = confirmationUrl;
-        this.xAdESReference = xAdESReference;
+        this.signatures = signatures;
         this.pAdESReference = pAdESReference;
     }
 
@@ -71,16 +72,16 @@ public class DirectJobStatusResponse implements Confirmable {
         return this.status == status;
     }
 
-    public XAdESReference getxAdESUrl() {
-        return xAdESReference;
-    }
-
     public boolean isPAdESAvailable() {
         return pAdESReference != null;
     }
 
     public PAdESReference getpAdESUrl() {
         return pAdESReference;
+    }
+
+    public List<Signature> getSignatures() {
+        return signatures;
     }
 
     @Override
@@ -92,4 +93,5 @@ public class DirectJobStatusResponse implements Confirmable {
     public String toString() {
         return "status for direct job with ID " + signatureJobId + ": " + status;
     }
+
 }

--- a/src/main/java/no/digipost/signature/client/direct/DirectJobStatusResponse.java
+++ b/src/main/java/no/digipost/signature/client/direct/DirectJobStatusResponse.java
@@ -18,10 +18,13 @@ package no.digipost.signature.client.direct;
 import no.digipost.signature.client.core.ConfirmationReference;
 import no.digipost.signature.client.core.PAdESReference;
 import no.digipost.signature.client.core.internal.Confirmable;
+import no.motif.f.Fn0;
 
 import java.util.List;
 
 import static no.digipost.signature.client.direct.DirectJobStatus.NO_CHANGES;
+import static no.digipost.signature.client.direct.Signature.signatureFrom;
+import static no.motif.Iterate.on;
 
 
 public class DirectJobStatusResponse implements Confirmable {
@@ -82,6 +85,24 @@ public class DirectJobStatusResponse implements Confirmable {
 
     public List<Signature> getSignatures() {
         return signatures;
+    }
+
+    /**
+     * Gets the signature from a given signer.
+     *
+     * @throws IllegalArgumentException if the job response doesn't contain a signature from this signer
+     * @see #getSignatures()
+     */
+    public Signature getSignatureFrom(final String personalIdentificationNumber) {
+        return on(signatures)
+                .filter(signatureFrom(personalIdentificationNumber))
+                .head()
+                .orElseThrow(new Fn0<IllegalArgumentException>() {
+                    @Override
+                    public IllegalArgumentException $() {
+                        return new IllegalArgumentException("Unable to find signature from this signer");
+                    }
+                });
     }
 
     @Override

--- a/src/main/java/no/digipost/signature/client/direct/JaxbEntityMapping.java
+++ b/src/main/java/no/digipost/signature/client/direct/JaxbEntityMapping.java
@@ -22,7 +22,6 @@ import no.digipost.signature.client.core.XAdESReference;
 import no.digipost.signature.client.direct.RedirectUrls.RedirectUrl;
 import no.motif.f.Fn;
 import no.motif.f.Predicate;
-import no.motif.single.Optional;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -54,10 +53,11 @@ final class JaxbEntityMapping {
     static DirectJobStatusResponse fromJaxb(XMLDirectSignatureJobStatusResponse statusResponse) {
         List<Signature> signatures = new ArrayList<>();
         for (XMLSignerStatus signerStatus : statusResponse.getStatuses()) {
-            Optional<String> xAdESUrl = on(statusResponse.getXadesUrls())
+            String xAdESUrl = on(statusResponse.getXadesUrls())
                     .filter(forSigner(signerStatus.getSigner()))
                     .head()
-                    .map(getUrl());
+                    .map(getUrl())
+                    .orNull();
 
             signatures.add(new Signature(
                     signerStatus.getSigner(),

--- a/src/main/java/no/digipost/signature/client/direct/JaxbEntityMapping.java
+++ b/src/main/java/no/digipost/signature/client/direct/JaxbEntityMapping.java
@@ -15,13 +15,19 @@
  */
 package no.digipost.signature.client.direct;
 
-import no.digipost.signature.api.xml.XMLDirectSignatureJobRequest;
-import no.digipost.signature.api.xml.XMLDirectSignatureJobResponse;
-import no.digipost.signature.api.xml.XMLDirectSignatureJobStatusResponse;
-import no.digipost.signature.api.xml.XMLExitUrls;
+import no.digipost.signature.api.xml.*;
 import no.digipost.signature.client.core.ConfirmationReference;
 import no.digipost.signature.client.core.PAdESReference;
 import no.digipost.signature.client.core.XAdESReference;
+import no.digipost.signature.client.direct.RedirectUrls.RedirectUrl;
+import no.motif.f.Fn;
+import no.motif.f.Predicate;
+import no.motif.single.Optional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static no.motif.Iterate.on;
 
 final class JaxbEntityMapping {
 
@@ -37,14 +43,46 @@ final class JaxbEntityMapping {
     }
 
     static DirectJobResponse fromJaxb(XMLDirectSignatureJobResponse xmlSignatureJobResponse) {
-        return new DirectJobResponse(xmlSignatureJobResponse.getSignatureJobId(), xmlSignatureJobResponse.getRedirectUrl(), xmlSignatureJobResponse.getStatusUrl());
+        List<RedirectUrl> redirectUrls = new ArrayList<>();
+        for (XMLSignerSpecificUrl redirectUrl : xmlSignatureJobResponse.getRedirectUrls()) {
+            redirectUrls.add(new RedirectUrl(redirectUrl.getSigner(), redirectUrl.getValue()));
+        }
+
+        return new DirectJobResponse(xmlSignatureJobResponse.getSignatureJobId(), redirectUrls, xmlSignatureJobResponse.getStatusUrl());
     }
 
     static DirectJobStatusResponse fromJaxb(XMLDirectSignatureJobStatusResponse statusResponse) {
+        List<Signature> signatures = new ArrayList<>();
+        for (XMLSignerStatus signerStatus : statusResponse.getStatuses()) {
+            Optional<String> xAdESUrl = on(statusResponse.getXadesUrls())
+                    .filter(forSigner(signerStatus.getSigner()))
+                    .head()
+                    .map(getUrl());
+
+            signatures.add(new Signature(
+                    signerStatus.getSigner(),
+                    SignerStatus.fromXmlType(signerStatus.getValue()),
+                    XAdESReference.of(xAdESUrl)
+            ));
+        }
+
         return new DirectJobStatusResponse(
-                statusResponse.getSignatureJobId(), DirectJobStatus.fromXmlType(statusResponse.getStatus()),
+                statusResponse.getSignatureJobId(),
+                DirectJobStatus.fromXmlType(statusResponse.getSignatureJobStatus()),
                 ConfirmationReference.of(statusResponse.getConfirmationUrl()),
-                XAdESReference.of(statusResponse.getXadesUrl()),
+                signatures,
                 PAdESReference.of(statusResponse.getPadesUrl()));
+    }
+
+    private static Fn<XMLSignerSpecificUrl, String> getUrl() {
+        return new Fn<XMLSignerSpecificUrl, String>() {
+            @Override public String $(XMLSignerSpecificUrl url) { return url.getValue(); }
+        };
+    }
+
+    private static Predicate<XMLSignerSpecificUrl> forSigner(final String signer) {
+        return new Predicate<XMLSignerSpecificUrl>() {
+            @Override public boolean $(XMLSignerSpecificUrl url) { return url.getSigner().equals(signer); }
+        };
     }
 }

--- a/src/main/java/no/digipost/signature/client/direct/RedirectUrls.java
+++ b/src/main/java/no/digipost/signature/client/direct/RedirectUrls.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (C) Posten Norge AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.signature.client.direct;
+
+import java.util.List;
+
+public class RedirectUrls {
+
+    private List<RedirectUrl> urls;
+
+    RedirectUrls(List<RedirectUrl> urls) {
+        this.urls = urls;
+    }
+
+    String getSingleRedirectUrl() {
+        if (urls.size() != 1) {
+            throw new IllegalStateException("Calls to this method should only be done when there are no more than one (1) redirect URL.");
+        }
+        return urls.get(0).getUrl();
+    }
+
+    public String getFor(String personalIdentificationNumber) {
+        for (RedirectUrl redirectUrl : urls) {
+            if (redirectUrl.signer.equals(personalIdentificationNumber)) {
+                return redirectUrl.url;
+            }
+        }
+        throw new IllegalArgumentException("Unable to find redirect URL for this signer");
+    }
+
+    public static class RedirectUrl {
+
+        private final String signer;
+
+        private final String url;
+
+        public RedirectUrl(String signer, String url) {
+            this.signer = signer;
+            this.url = url;
+        }
+
+        public String getSigner() {
+            return signer;
+        }
+
+        public String getUrl() {
+            return url;
+        }
+
+    }
+
+}

--- a/src/main/java/no/digipost/signature/client/direct/RedirectUrls.java
+++ b/src/main/java/no/digipost/signature/client/direct/RedirectUrls.java
@@ -32,6 +32,11 @@ public class RedirectUrls {
         return urls.get(0).getUrl();
     }
 
+    /**
+     * Gets the redirect URL for a given signer.
+     * @throws IllegalArgumentException if the job response doesn't contain a redirect URL for this signer
+     * @see DirectJobResponse#getSingleRedirectUrl()
+     */
     public String getFor(String personalIdentificationNumber) {
         for (RedirectUrl redirectUrl : urls) {
             if (redirectUrl.signer.equals(personalIdentificationNumber)) {
@@ -39,6 +44,10 @@ public class RedirectUrls {
             }
         }
         throw new IllegalArgumentException("Unable to find redirect URL for this signer");
+    }
+
+    public List<RedirectUrl> getAll() {
+        return urls;
     }
 
     public static class RedirectUrl {

--- a/src/main/java/no/digipost/signature/client/direct/Signature.java
+++ b/src/main/java/no/digipost/signature/client/direct/Signature.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (C) Posten Norge AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.signature.client.direct;
+
+import no.digipost.signature.client.core.XAdESReference;
+
+import static no.digipost.signature.client.direct.DirectSigner.mask;
+
+
+public class Signature {
+
+    private final String signer;
+    private final SignerStatus status;
+    private final XAdESReference xAdESReference;
+
+    public Signature(String signer, SignerStatus status, XAdESReference xAdESReference) {
+        this.signer = signer;
+        this.status = status;
+        this.xAdESReference = xAdESReference;
+    }
+
+    public boolean is(SignerStatus status) {
+        return this.status == status;
+    }
+
+    public String getSigner() {
+        return signer;
+    }
+
+    public SignerStatus getStatus() {
+        return status;
+    }
+
+    public XAdESReference getxAdESUrl() {
+        return xAdESReference;
+    }
+
+    @Override
+    public String toString() {
+        return "Signature from " + mask(signer) + " with status '" + status + "'" + (xAdESReference != null ? ". XAdES available at " + xAdESReference.getxAdESUrl() : "");
+    }
+
+
+}

--- a/src/main/java/no/digipost/signature/client/direct/Signature.java
+++ b/src/main/java/no/digipost/signature/client/direct/Signature.java
@@ -16,6 +16,7 @@
 package no.digipost.signature.client.direct;
 
 import no.digipost.signature.client.core.XAdESReference;
+import no.motif.f.Predicate;
 
 import static no.digipost.signature.client.direct.DirectSigner.mask;
 
@@ -40,6 +41,10 @@ public class Signature {
         return signer;
     }
 
+    public boolean isFrom(String personalIdentificationNumber) {
+        return this.signer.equals(personalIdentificationNumber);
+    }
+
     public SignerStatus getStatus() {
         return status;
     }
@@ -51,6 +56,15 @@ public class Signature {
     @Override
     public String toString() {
         return "Signature from " + mask(signer) + " with status '" + status + "'" + (xAdESReference != null ? ". XAdES available at " + xAdESReference.getxAdESUrl() : "");
+    }
+
+    static Predicate<Signature> signatureFrom(final String personalIdentificationNumber) {
+        return new Predicate<Signature>() {
+            @Override
+            public boolean $(Signature signature) {
+                return signature.isFrom(personalIdentificationNumber);
+            }
+        };
     }
 
 

--- a/src/main/java/no/digipost/signature/client/direct/SignerStatus.java
+++ b/src/main/java/no/digipost/signature/client/direct/SignerStatus.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright (C) Posten Norge AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.signature.client.direct;
+
+import java.util.List;
+import java.util.Objects;
+
+import static java.util.Arrays.asList;
+
+public class SignerStatus {
+
+    /**
+     * The signer has rejected to sign the document.
+     */
+    public static final SignerStatus REJECTED = new SignerStatus("REJECTED");
+
+    /**
+     * The signer has not made a decision to either sign or reject the document within the
+     * specified time limit.
+     */
+    public static final SignerStatus EXPIRED = new SignerStatus("EXPIRED");
+
+    /**
+     * The signer has yet to review the document and decide if she/he wants to sign or
+     * reject it.
+     */
+    public static final SignerStatus WAITING = new SignerStatus("WAITING");
+
+    /**
+     * The signer has successfully signed the document.
+     */
+    public static final SignerStatus SIGNED = new SignerStatus("SIGNED");
+    /**
+     * The signer has successfully signed the document.
+     */
+    public static final SignerStatus FAILED = new SignerStatus("FAILED");
+
+
+    private static final List<SignerStatus> KNOWN_STATUSES = asList(
+            REJECTED,
+            EXPIRED,
+            WAITING,
+            SIGNED,
+            FAILED
+    );
+
+    private final String identifier;
+
+
+    public SignerStatus(String identifier) {
+        this.identifier = identifier;
+    }
+
+    public static SignerStatus fromXmlType(String xmlSignerStatus) {
+        for (SignerStatus status : KNOWN_STATUSES) {
+            if (status.is(xmlSignerStatus)) {
+                return status;
+            }
+        }
+
+        return new SignerStatus(xmlSignerStatus);
+    }
+
+    private boolean is(String xmlSignerStatus) {
+        return this.identifier.equals(xmlSignerStatus);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o instanceof SignerStatus) {
+            SignerStatus that = (SignerStatus) o;
+            return Objects.equals(identifier, that.identifier);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(identifier);
+    }
+
+    @Override
+    public String toString() {
+        return identifier;
+    }
+
+}

--- a/src/main/java/no/digipost/signature/client/direct/SignerStatus.java
+++ b/src/main/java/no/digipost/signature/client/direct/SignerStatus.java
@@ -44,7 +44,7 @@ public class SignerStatus {
      */
     public static final SignerStatus SIGNED = new SignerStatus("SIGNED");
     /**
-     * The signer has successfully signed the document.
+     * An unexpected error occured during the signing ceremony.
      */
     public static final SignerStatus FAILED = new SignerStatus("FAILED");
 

--- a/src/test/java/no/digipost/signature/client/asice/CreateASiCETest.java
+++ b/src/test/java/no/digipost/signature/client/asice/CreateASiCETest.java
@@ -65,14 +65,14 @@ public class CreateASiCETest {
         Files.createDirectories(dumpFolder);
     }
 
-    public static Path dumpFolder;
+    private static Path dumpFolder;
 
-    public static final DirectDocument DIRECT_DOCUMENT = DirectDocument.builder("Title", "file.txt", "hello".getBytes())
+    private static final DirectDocument DIRECT_DOCUMENT = DirectDocument.builder("Title", "file.txt", "hello".getBytes())
             .message("Message")
             .fileType(Document.FileType.TXT)
             .build();
 
-    public static final PortalDocument PORTAL_DOCUMENT = PortalDocument.builder("Title", "file.txt", "hello".getBytes())
+    private static final PortalDocument PORTAL_DOCUMENT = PortalDocument.builder("Title", "file.txt", "hello".getBytes())
             .message("Message")
             .fileType(Document.FileType.TXT)
             .build();
@@ -81,7 +81,7 @@ public class CreateASiCETest {
 
     @Test
     public void create_direct_asice_and_write_to_disk() throws IOException {
-        DirectJob job = DirectJob.builder(DirectSigner.builder("12345678910").build(), DIRECT_DOCUMENT, singleExitUrl("https://job.well.done.org"))
+        DirectJob job = DirectJob.builder(DIRECT_DOCUMENT, singleExitUrl("https://job.well.done.org"), DirectSigner.builder("12345678910").build())
                 .withReference("direct job")
                 .build();
 

--- a/src/test/java/no/digipost/signature/client/asice/manifest/CreateDirectManifestTest.java
+++ b/src/test/java/no/digipost/signature/client/asice/manifest/CreateDirectManifestTest.java
@@ -36,7 +36,7 @@ public class CreateDirectManifestTest {
                 .fileType(Document.FileType.TXT)
                 .build();
 
-        DirectJob job = DirectJob.builder(DirectSigner.builder("12345678910").build(), document, ExitUrls.of("http://localhost/signed", "http://localhost/canceled", "http://localhost/failed")).build();
+        DirectJob job = DirectJob.builder(document, ExitUrls.of("http://localhost/signed", "http://localhost/canceled", "http://localhost/failed"), DirectSigner.builder("12345678910").build()).build();
         try {
             createManifest.createManifest(job, new Sender("123456789"));
         } catch (Exception e) {

--- a/src/test/java/no/digipost/signature/client/core/internal/xml/MarshallingTest.java
+++ b/src/test/java/no/digipost/signature/client/core/internal/xml/MarshallingTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 import org.springframework.oxm.MarshallingFailureException;
 
 import java.io.ByteArrayOutputStream;
+import java.util.Arrays;
 import java.util.Date;
 
 import static junit.framework.TestCase.assertEquals;
@@ -45,7 +46,7 @@ public class MarshallingTest {
                 .withErrorUrl("http://localhost/failed");
 
         XMLDirectSignatureJobRequest directJob = new XMLDirectSignatureJobRequest("123abc", exitUrls, null);
-        XMLDirectSignatureJobManifest directManifest = new XMLDirectSignatureJobManifest(directSigner, sender, directDocument);
+        XMLDirectSignatureJobManifest directManifest = new XMLDirectSignatureJobManifest(Arrays.asList(directSigner), sender, directDocument);
 
         marshal(directJob, new ByteArrayOutputStream());
         marshal(directManifest, new ByteArrayOutputStream());
@@ -81,7 +82,7 @@ public class MarshallingTest {
         XMLPortalDocument portalDocument = new XMLPortalDocument("Title", "Non-sensitive title", "Message", null, "application/pdf");
         XMLDirectDocument directDocument = new XMLDirectDocument("Title", "Message", null, "application/pdf");
 
-        XMLDirectSignatureJobManifest directManifest = new XMLDirectSignatureJobManifest(directSigner, sender, directDocument);
+        XMLDirectSignatureJobManifest directManifest = new XMLDirectSignatureJobManifest(Arrays.asList(directSigner), sender, directDocument);
         XMLPortalSignatureJobManifest portalManifest = new XMLPortalSignatureJobManifest(new XMLPortalSigners().withSigners(portalSigner), sender, portalDocument, null);
 
         try {
@@ -98,7 +99,7 @@ public class MarshallingTest {
         XMLDirectSignatureJobStatusResponse unmarshalled = (XMLDirectSignatureJobStatusResponse) unmarshal(this.getClass().getResourceAsStream("/xml/direct_signature_job_response_with_unexpected_element.xml"));
 
         assertEquals(1, unmarshalled.getSignatureJobId());
-        assertEquals("SIGNED", unmarshalled.getStatus().name());
+        assertEquals("SIGNED", unmarshalled.getStatuses().get(0).getValue());
     }
 
 }


### PR DESCRIPTION
Innfører mulighet for å spesifisere opptil 10 signatarer for synkrone oppdrag (tilsvarende som asynkrone oppdrag).

Responser fra tjenesten er utvidet til å returnere en del informasjon pr. signatar, f.eks. `redirect-URL`er ved opprettelse og ulike `status`er ved henting av status for et oppdrag.