### PR TITLE
Fødselsnummer-masking lagt i én util-metode + test av denne

### DIFF
--- a/src/main/java/no/digipost/signature/client/core/internal/PersonalIdentificationNumbers.java
+++ b/src/main/java/no/digipost/signature/client/core/internal/PersonalIdentificationNumbers.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (C) Posten Norge AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.signature.client.core.internal;
+
+import static java.util.Arrays.fill;
+
+public final class PersonalIdentificationNumbers {
+
+    public static String mask(String personalIdentificationNumber) {
+        if (personalIdentificationNumber == null) {
+            return null;
+        } else if (personalIdentificationNumber.length() < 6) {
+            return personalIdentificationNumber;
+        }
+        char[] masking = new char[personalIdentificationNumber.length() - 6];
+        fill(masking, '*');
+        return personalIdentificationNumber.substring(0, 6) + new String(masking);
+    }
+
+    private PersonalIdentificationNumbers() { }
+
+}

--- a/src/main/java/no/digipost/signature/client/direct/DirectSigner.java
+++ b/src/main/java/no/digipost/signature/client/direct/DirectSigner.java
@@ -15,6 +15,8 @@
  */
 package no.digipost.signature.client.direct;
 
+import static no.digipost.signature.client.core.internal.PersonalIdentificationNumbers.mask;
+
 public class DirectSigner {
 
     public static DirectSigner withPersonalIdentificationNumber(String personalIdentificationNumber) {
@@ -56,10 +58,6 @@ public class DirectSigner {
     @Override
     public String toString() {
         return DirectSigner.class.getSimpleName() + ": " + (isIdentifiedByPersonalIdentificationNumber() ? mask(personalIdentificationNumber) : customIdentifier);
-    }
-
-    static String mask(String personalIdentificationNumber) {
-        return personalIdentificationNumber.substring(0, 6) + "*****";
     }
 
 }

--- a/src/main/java/no/digipost/signature/client/direct/Signature.java
+++ b/src/main/java/no/digipost/signature/client/direct/Signature.java
@@ -18,7 +18,7 @@ package no.digipost.signature.client.direct;
 import no.digipost.signature.client.core.XAdESReference;
 import no.motif.f.Predicate;
 
-import static no.digipost.signature.client.direct.DirectSigner.mask;
+import static no.digipost.signature.client.core.internal.PersonalIdentificationNumbers.mask;
 
 
 public class Signature {

--- a/src/main/java/no/digipost/signature/client/portal/PortalSigner.java
+++ b/src/main/java/no/digipost/signature/client/portal/PortalSigner.java
@@ -15,6 +15,8 @@
  */
 package no.digipost.signature.client.portal;
 
+import static no.digipost.signature.client.core.internal.PersonalIdentificationNumbers.mask;
+
 public class PortalSigner {
 
     private final String personalIdentificationNumber;
@@ -47,10 +49,6 @@ public class PortalSigner {
     @Override
     public String toString() {
         return mask(personalIdentificationNumber);
-    }
-
-    static String mask(String personalIdentificationNumber) {
-        return personalIdentificationNumber.substring(0, 6) + "*****";
     }
 
     public static Builder builder(String personalIdentificationNumber, Notifications notifications) {

--- a/src/main/java/no/digipost/signature/client/portal/Signature.java
+++ b/src/main/java/no/digipost/signature/client/portal/Signature.java
@@ -17,7 +17,7 @@ package no.digipost.signature.client.portal;
 
 import no.digipost.signature.client.core.XAdESReference;
 
-import static no.digipost.signature.client.portal.PortalSigner.mask;
+import static no.digipost.signature.client.core.internal.PersonalIdentificationNumbers.mask;
 
 public class Signature {
 

--- a/src/test/java/no/digipost/signature/client/core/internal/PersonalIdentificationNumbersTest.java
+++ b/src/test/java/no/digipost/signature/client/core/internal/PersonalIdentificationNumbersTest.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (C) Posten Norge AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.signature.client.core.internal;
+
+import com.pholser.junit.quickcheck.ForAll;
+import org.junit.Test;
+import org.junit.contrib.theories.Theories;
+import org.junit.contrib.theories.Theory;
+import org.junit.runner.RunWith;
+
+import static no.digipost.signature.client.core.internal.PersonalIdentificationNumbers.mask;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isA;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+@RunWith(Theories.class)
+public class PersonalIdentificationNumbersTest {
+
+    @Theory
+    public void maskingNeverThrowsException(@ForAll String randomString) {
+        assertThat(mask(randomString), isA(String.class));
+    }
+
+    @Theory
+    public void alwaysReturnsStringWithSameLengthAsGiven(@ForAll String randomString) {
+        assertThat(mask(randomString).length(), is(randomString.length()));
+    }
+
+    @Test
+    public void masksTheIdPartOfAPersonalIdentificationNumber() {
+        assertThat(mask("24068112345"), is("240681*****"));
+    }
+
+    @Test
+    public void maskingNullIsNull() {
+        assertThat(mask(null), nullValue());
+    }
+
+}


### PR DESCRIPTION
Fikser en potensiell exception som blir kastet dersom man forsøker å
"mask-e" noe annet enn fødselsnummer. Tester at mask er excpetion-safe
med junit-quickcheck.

`mask(String fnr)` lå duplisert i PortalSigner og DirectSigner. Legger denne i `no.digipost.signature.client.core.internal.PersonalIdentificationNumbers` i stedet.

