### PR TITLE
Oppdaterer API-spesifikasjon til versjon 1.5.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <properties>
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
-        <signature.api.version>1.5</signature.api.version>
+        <signature.api.version>1.5.2</signature.api.version>
         <slf4j.version>1.7.21</slf4j.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <name>Posten signering - Java API Client Library</name>
     <groupId>no.digipost.signature</groupId>
     <artifactId>signature-api-client-java</artifactId>
-    <version>2.1-SNAPSHOT</version>
+    <version>2.0.1</version>
 
     <parent>
         <groupId>no.digipost</groupId>
@@ -442,7 +442,7 @@
         <connection>scm:git:git@github.com:digipost/signature-api-client-java.git</connection>
         <developerConnection>scm:git:git@github.com:digipost/signature-api-client-java.git</developerConnection>
         <url>https://github.com/digipost/signature-api-client-java/</url>
-        <tag>HEAD</tag>
+        <tag>2.0.1</tag>
     </scm>
 
     <prerequisites>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <name>Posten signering - Java API Client Library</name>
     <groupId>no.digipost.signature</groupId>
     <artifactId>signature-api-client-java</artifactId>
-    <version>2.0.1</version>
+    <version>2.1-SNAPSHOT</version>
 
     <parent>
         <groupId>no.digipost</groupId>
@@ -442,7 +442,7 @@
         <connection>scm:git:git@github.com:digipost/signature-api-client-java.git</connection>
         <developerConnection>scm:git:git@github.com:digipost/signature-api-client-java.git</developerConnection>
         <url>https://github.com/digipost/signature-api-client-java/</url>
-        <tag>2.0.1</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <prerequisites>

--- a/src/main/java/no/digipost/signature/client/asice/manifest/CreatePortalManifest.java
+++ b/src/main/java/no/digipost/signature/client/asice/manifest/CreatePortalManifest.java
@@ -24,7 +24,6 @@ import no.digipost.signature.api.xml.XMLNotificationsUsingLookup;
 import no.digipost.signature.api.xml.XMLPortalDocument;
 import no.digipost.signature.api.xml.XMLPortalSignatureJobManifest;
 import no.digipost.signature.api.xml.XMLPortalSigner;
-import no.digipost.signature.api.xml.XMLPortalSigners;
 import no.digipost.signature.api.xml.XMLSender;
 import no.digipost.signature.api.xml.XMLSignatureType;
 import no.digipost.signature.api.xml.XMLSms;
@@ -36,11 +35,14 @@ import no.digipost.signature.client.portal.PortalDocument;
 import no.digipost.signature.client.portal.PortalJob;
 import no.digipost.signature.client.portal.PortalSigner;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class CreatePortalManifest extends ManifestCreator<PortalJob> {
 
     @Override
     Object buildXmlManifest(PortalJob job, Sender sender) {
-        XMLPortalSigners xmlSigners = new XMLPortalSigners();
+        List<XMLPortalSigner> xmlSigners = new ArrayList<>();
         for (PortalSigner signer : job.getSigners()) {
             XMLPortalSigner xmlPortalSigner = new XMLPortalSigner()
                     .withPersonalIdentificationNumber(signer.getPersonalIdentificationNumber())
@@ -52,8 +54,7 @@ public class CreatePortalManifest extends ManifestCreator<PortalJob> {
             } else if (signer.getNotificationsUsingLookup() != null) {
                 xmlPortalSigner.setNotificationsUsingLookup(generateNotificationsUsingLookup(signer.getNotificationsUsingLookup()));
             }
-
-            xmlSigners.getSigners().add(xmlPortalSigner);
+            xmlSigners.add(xmlPortalSigner);
         }
 
         PortalDocument document = job.getDocument();


### PR DESCRIPTION
I denne versjonen er `XMLPortalSigners`-wrapper-elementet fjernet fra de genererte JAXB-klassene. Gjør dermed de nødvendige fiksene for å få klienten til å kompilere :-)