### PR TITLE
Støtte for on-behalf-of i klienten

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <properties>
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
-        <signature.api.version>1.7.SIGNING-FOR-SNAPSHOT</signature.api.version>
+        <signature.api.version>1.7</signature.api.version>
         <slf4j.version>1.7.21</slf4j.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <name>Posten signering - Java API Client Library</name>
     <groupId>no.digipost.signature</groupId>
     <artifactId>signature-api-client-java</artifactId>
-    <version>2.2-SNAPSHOT</version>
+    <version>2.2.SIGNING-FOR-SNAPSHOT</version>
 
     <parent>
         <groupId>no.digipost</groupId>
@@ -16,7 +16,7 @@
     <properties>
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
-        <signature.api.version>1.6</signature.api.version>
+        <signature.api.version>1.7.SIGNING-FOR-SNAPSHOT</signature.api.version>
         <slf4j.version>1.7.21</slf4j.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <name>Posten signering - Java API Client Library</name>
     <groupId>no.digipost.signature</groupId>
     <artifactId>signature-api-client-java</artifactId>
-    <version>2.2.SIGNING-FOR-SNAPSHOT</version>
+    <version>2.2</version>
 
     <parent>
         <groupId>no.digipost</groupId>
@@ -442,7 +442,7 @@
         <connection>scm:git:git@github.com:digipost/signature-api-client-java.git</connection>
         <developerConnection>scm:git:git@github.com:digipost/signature-api-client-java.git</developerConnection>
         <url>https://github.com/digipost/signature-api-client-java/</url>
-        <tag>HEAD</tag>
+        <tag>2.2</tag>
     </scm>
 
     <prerequisites>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <name>Posten signering - Java API Client Library</name>
     <groupId>no.digipost.signature</groupId>
     <artifactId>signature-api-client-java</artifactId>
-    <version>2.2</version>
+    <version>2.3-SNAPSHOT</version>
 
     <parent>
         <groupId>no.digipost</groupId>
@@ -442,7 +442,7 @@
         <connection>scm:git:git@github.com:digipost/signature-api-client-java.git</connection>
         <developerConnection>scm:git:git@github.com:digipost/signature-api-client-java.git</developerConnection>
         <url>https://github.com/digipost/signature-api-client-java/</url>
-        <tag>2.2</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <prerequisites>

--- a/src/main/java/no/digipost/signature/client/asice/manifest/CreateDirectManifest.java
+++ b/src/main/java/no/digipost/signature/client/asice/manifest/CreateDirectManifest.java
@@ -21,6 +21,7 @@ import no.digipost.signature.api.xml.XMLDirectSignatureJobManifest;
 import no.digipost.signature.api.xml.XMLDirectSigner;
 import no.digipost.signature.api.xml.XMLSender;
 import no.digipost.signature.api.xml.XMLSignatureType;
+import no.digipost.signature.api.xml.XMLSigningOnBehalfOf;
 import no.digipost.signature.client.core.Sender;
 import no.digipost.signature.client.core.internal.MarshallableEnum;
 import no.digipost.signature.client.direct.DirectDocument;
@@ -39,7 +40,8 @@ public class CreateDirectManifest extends ManifestCreator<DirectJob> {
         List<XMLDirectSigner> signers = new ArrayList<>();
         for (DirectSigner signer : job.getSigners()) {
             XMLDirectSigner xmlSigner = new XMLDirectSigner()
-                    .withSignatureType(signer.getSignatureType().map(MarshallableEnum.To.<XMLSignatureType>xmlValue()).orNull());
+                    .withSignatureType(signer.getSignatureType().map(MarshallableEnum.To.<XMLSignatureType>xmlValue()).orNull())
+                    .withOnBehalfOf(signer.getOnBehalfOf().map(MarshallableEnum.To.<XMLSigningOnBehalfOf>xmlValue()).orNull());
             if (signer.isIdentifiedByPersonalIdentificationNumber()) {
                 xmlSigner.setPersonalIdentificationNumber(signer.getPersonalIdentificationNumber());
             } else {

--- a/src/main/java/no/digipost/signature/client/asice/manifest/CreatePortalManifest.java
+++ b/src/main/java/no/digipost/signature/client/asice/manifest/CreatePortalManifest.java
@@ -26,6 +26,7 @@ import no.digipost.signature.api.xml.XMLPortalSignatureJobManifest;
 import no.digipost.signature.api.xml.XMLPortalSigner;
 import no.digipost.signature.api.xml.XMLSender;
 import no.digipost.signature.api.xml.XMLSignatureType;
+import no.digipost.signature.api.xml.XMLSigningOnBehalfOf;
 import no.digipost.signature.api.xml.XMLSms;
 import no.digipost.signature.client.core.Sender;
 import no.digipost.signature.client.core.internal.MarshallableEnum;
@@ -47,7 +48,8 @@ public class CreatePortalManifest extends ManifestCreator<PortalJob> {
             XMLPortalSigner xmlPortalSigner = new XMLPortalSigner()
                     .withPersonalIdentificationNumber(signer.getPersonalIdentificationNumber())
                     .withOrder(signer.getOrder())
-                    .withSignatureType(signer.getSignatureType().map(MarshallableEnum.To.<XMLSignatureType>xmlValue()).orNull());
+                    .withSignatureType(signer.getSignatureType().map(MarshallableEnum.To.<XMLSignatureType>xmlValue()).orNull())
+                    .withOnBehalfOf(signer.getOnBehalfOf().map(MarshallableEnum.To.<XMLSigningOnBehalfOf>xmlValue()).orNull());
 
             if (signer.getNotifications() != null) {
                 xmlPortalSigner.setNotifications(generateNotifications(signer.getNotifications()));

--- a/src/main/java/no/digipost/signature/client/core/OnBehalfOf.java
+++ b/src/main/java/no/digipost/signature/client/core/OnBehalfOf.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (C) Posten Norge AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.signature.client.core;
+
+import no.digipost.signature.api.xml.XMLSigningOnBehalfOf;
+import no.digipost.signature.client.core.internal.MarshallableEnum;
+
+/**
+ * Specifies if the signer signs on behalf of itself or some other party
+ */
+public enum OnBehalfOf implements MarshallableEnum<XMLSigningOnBehalfOf> {
+
+    SELF(XMLSigningOnBehalfOf.SELF),
+    OTHER(XMLSigningOnBehalfOf.OTHER);
+
+    private final XMLSigningOnBehalfOf xmlEnumValue;
+
+    OnBehalfOf(XMLSigningOnBehalfOf xmlEnumValue) {
+        this.xmlEnumValue = xmlEnumValue;
+    }
+
+    @Override
+    public XMLSigningOnBehalfOf getXmlEnumValue() {
+        return xmlEnumValue;
+    }
+
+}

--- a/src/main/java/no/digipost/signature/client/core/internal/SignerCustomizations.java
+++ b/src/main/java/no/digipost/signature/client/core/internal/SignerCustomizations.java
@@ -15,6 +15,7 @@
  */
 package no.digipost.signature.client.core.internal;
 
+import no.digipost.signature.client.core.OnBehalfOf;
 import no.digipost.signature.client.core.SignatureType;
 
 /**
@@ -30,5 +31,7 @@ public interface SignerCustomizations<B extends SignerCustomizations<B>> {
      * @param type the {@link SignatureType}
      */
     B withSignatureType(SignatureType type);
+
+    B withOnBehalfOf(OnBehalfOf onBehalfOf);
 
 }

--- a/src/main/java/no/digipost/signature/client/core/internal/SignerCustomizations.java
+++ b/src/main/java/no/digipost/signature/client/core/internal/SignerCustomizations.java
@@ -32,6 +32,11 @@ public interface SignerCustomizations<B extends SignerCustomizations<B>> {
      */
     B withSignatureType(SignatureType type);
 
-    B withOnBehalfOf(OnBehalfOf onBehalfOf);
+    /**
+     * Specify which party the signer is {@link OnBehalfOf signing on behalf of}.
+     *
+     * @param onBehalfOf the {@link OnBehalfOf}-value
+     */
+    B onBehalfOf(OnBehalfOf onBehalfOf);
 
 }

--- a/src/main/java/no/digipost/signature/client/direct/DirectSigner.java
+++ b/src/main/java/no/digipost/signature/client/direct/DirectSigner.java
@@ -15,6 +15,7 @@
  */
 package no.digipost.signature.client.direct;
 
+import no.digipost.signature.client.core.OnBehalfOf;
 import no.digipost.signature.client.core.SignatureType;
 import no.digipost.signature.client.core.internal.SignerCustomizations;
 import no.motif.Singular;
@@ -38,6 +39,7 @@ public class DirectSigner {
         private String personalIdentificationNumber;
         private String customIdentifier;
         private Optional<SignatureType> signatureType = Singular.none();
+        private Optional<OnBehalfOf> onBehalfOf = Singular.none();
 
         private Builder(String personalIdentificationNumber, String customIdentifier) {
             this.personalIdentificationNumber = personalIdentificationNumber;
@@ -50,8 +52,14 @@ public class DirectSigner {
             return this;
         }
 
+        @Override
+        public Builder withOnBehalfOf(OnBehalfOf onBehalfOf) {
+            this.onBehalfOf = optional(onBehalfOf);
+            return this;
+        }
+
         public DirectSigner build() {
-            return new DirectSigner(personalIdentificationNumber, customIdentifier, signatureType);
+            return new DirectSigner(personalIdentificationNumber, customIdentifier, signatureType, onBehalfOf);
         }
 
     }
@@ -61,11 +69,13 @@ public class DirectSigner {
     private final String personalIdentificationNumber;
     private final String customIdentifier;
     private final Optional<SignatureType> signatureType;
+    private final Optional<OnBehalfOf> onBehalfOf;
 
-    private DirectSigner(String personalIdentificationNumber, String customIdentifier, Optional<SignatureType> signatureType) {
+    private DirectSigner(String personalIdentificationNumber, String customIdentifier, Optional<SignatureType> signatureType, Optional<OnBehalfOf> onBehalfOf) {
         this.personalIdentificationNumber = personalIdentificationNumber;
         this.customIdentifier = customIdentifier;
         this.signatureType = signatureType;
+        this.onBehalfOf = onBehalfOf;
     }
 
     public boolean isIdentifiedByPersonalIdentificationNumber() {
@@ -88,6 +98,10 @@ public class DirectSigner {
 
     public Optional<SignatureType> getSignatureType() {
         return signatureType;
+    }
+
+    public Optional<OnBehalfOf> getOnBehalfOf() {
+        return onBehalfOf;
     }
 
     @Override

--- a/src/main/java/no/digipost/signature/client/direct/DirectSigner.java
+++ b/src/main/java/no/digipost/signature/client/direct/DirectSigner.java
@@ -53,7 +53,7 @@ public class DirectSigner {
         }
 
         @Override
-        public Builder withOnBehalfOf(OnBehalfOf onBehalfOf) {
+        public Builder onBehalfOf(OnBehalfOf onBehalfOf) {
             this.onBehalfOf = optional(onBehalfOf);
             return this;
         }

--- a/src/main/java/no/digipost/signature/client/portal/PortalSigner.java
+++ b/src/main/java/no/digipost/signature/client/portal/PortalSigner.java
@@ -98,7 +98,7 @@ public class PortalSigner {
         }
 
         @Override
-        public Builder withOnBehalfOf(OnBehalfOf onBehalfOf) {
+        public Builder onBehalfOf(OnBehalfOf onBehalfOf) {
             target.onBehalfOf = optional(onBehalfOf);
             return this;
         }

--- a/src/main/java/no/digipost/signature/client/portal/PortalSigner.java
+++ b/src/main/java/no/digipost/signature/client/portal/PortalSigner.java
@@ -15,11 +15,13 @@
  */
 package no.digipost.signature.client.portal;
 
+import no.digipost.signature.client.core.OnBehalfOf;
 import no.digipost.signature.client.core.SignatureType;
 import no.digipost.signature.client.core.internal.SignerCustomizations;
 import no.motif.Singular;
 import no.motif.single.Optional;
 
+import static no.digipost.signature.client.core.OnBehalfOf.OTHER;
 import static no.digipost.signature.client.core.internal.PersonalIdentificationNumbers.mask;
 import static no.motif.Singular.optional;
 
@@ -30,6 +32,7 @@ public class PortalSigner {
     private final NotificationsUsingLookup notificationsUsingLookup;
     private int order = 0;
     private Optional<SignatureType> signatureType = Singular.none();
+    private Optional<OnBehalfOf> onBehalfOf = Singular.none();
 
     private PortalSigner(String personalIdentificationNumber, Notifications notifications, NotificationsUsingLookup notificationsUsingLookup) {
         this.personalIdentificationNumber = personalIdentificationNumber;
@@ -55,6 +58,10 @@ public class PortalSigner {
 
     public Optional<SignatureType> getSignatureType() {
         return signatureType;
+    }
+
+    public Optional<OnBehalfOf> getOnBehalfOf() {
+        return onBehalfOf;
     }
 
     @Override
@@ -90,7 +97,16 @@ public class PortalSigner {
             return this;
         }
 
+        @Override
+        public Builder withOnBehalfOf(OnBehalfOf onBehalfOf) {
+            target.onBehalfOf = optional(onBehalfOf);
+            return this;
+        }
+
         public PortalSigner build() {
+            if (target.onBehalfOf.isSome() && target.onBehalfOf.get() == OTHER && target.notificationsUsingLookup != null) {
+                throw new IllegalStateException("Can't look up contact information for notifications when signing on behalf of a third party");
+            }
             if (built) throw new IllegalStateException("Can't build twice");
             built = true;
             return target;


### PR DESCRIPTION
Feltet onBehalfOf skal valideres opp mot notifications, men en del av
disse valideringene er avhengig av sektor, som vi ikke har tilgjengelig
i klienten.
PortalSigner.Builder gjør den eneste valideringen vi kan gjøre, nemlig at
man ikke kan slå opp varslingsinfo når man signerer på vegne av noen
andre