### PR TITLE
Ekskluder fødselsnummer i signerte dokumenter

### DIFF
--- a/docs/_v2_x/3_portal_usecases.md
+++ b/docs/_v2_x/3_portal_usecases.md
@@ -48,6 +48,7 @@ You may identify the signature job's signers by personal identification number (
 
 Read more about identifying your signers in the [functional documentation](http://digipost.github.io/signature-api-specification/v1.0/#kontaktinfo) (Norwegian).
 
+> Note: Most domain object follow the builder pattern, accepting all required parameters in the factory method and with specific methods for each optional parameter. Keep this in mind when exploring the API.
 
 <h3 id="uc09">Get status changes</h3>
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <properties>
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
-        <signature.api.version>1.9-EXCLUDE_PIN-SNAPSHOT</signature.api.version>
+        <signature.api.version>1.9</signature.api.version>
         <slf4j.version>1.7.21</slf4j.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <name>Posten signering - Java API Client Library</name>
     <groupId>no.digipost.signature</groupId>
     <artifactId>signature-api-client-java</artifactId>
-    <version>2.4</version>
+    <version>2.5-SNAPSHOT</version>
 
     <parent>
         <groupId>no.digipost</groupId>
@@ -446,7 +446,7 @@
         <connection>scm:git:git@github.com:digipost/signature-api-client-java.git</connection>
         <developerConnection>scm:git:git@github.com:digipost/signature-api-client-java.git</developerConnection>
         <url>https://github.com/digipost/signature-api-client-java/</url>
-        <tag>2.4</tag>
+        <tag>HEAD</tag>
     </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <name>Posten signering - Java API Client Library</name>
     <groupId>no.digipost.signature</groupId>
     <artifactId>signature-api-client-java</artifactId>
-    <version>2.4-SNAPSHOT</version>
+    <version>2.4-EXCLUDE_PIN-SNAPSHOT</version>
 
     <parent>
         <groupId>no.digipost</groupId>
@@ -16,7 +16,7 @@
     <properties>
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
-        <signature.api.version>1.8</signature.api.version>
+        <signature.api.version>1.9-EXCLUDE_PIN-SNAPSHOT</signature.api.version>
         <slf4j.version>1.7.21</slf4j.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <name>Posten signering - Java API Client Library</name>
     <groupId>no.digipost.signature</groupId>
     <artifactId>signature-api-client-java</artifactId>
-    <version>2.4-EXCLUDE_PIN-SNAPSHOT</version>
+    <version>2.4</version>
 
     <parent>
         <groupId>no.digipost</groupId>
@@ -446,7 +446,7 @@
         <connection>scm:git:git@github.com:digipost/signature-api-client-java.git</connection>
         <developerConnection>scm:git:git@github.com:digipost/signature-api-client-java.git</developerConnection>
         <url>https://github.com/digipost/signature-api-client-java/</url>
-        <tag>HEAD</tag>
+        <tag>2.4</tag>
     </scm>
 
 </project>

--- a/src/main/java/no/digipost/signature/client/asice/manifest/CreateDirectManifest.java
+++ b/src/main/java/no/digipost/signature/client/asice/manifest/CreateDirectManifest.java
@@ -19,6 +19,7 @@ import no.digipost.signature.api.xml.XMLAuthenticationLevel;
 import no.digipost.signature.api.xml.XMLDirectDocument;
 import no.digipost.signature.api.xml.XMLDirectSignatureJobManifest;
 import no.digipost.signature.api.xml.XMLDirectSigner;
+import no.digipost.signature.api.xml.XMLIdentifierInSignedDocuments;
 import no.digipost.signature.api.xml.XMLSender;
 import no.digipost.signature.api.xml.XMLSignatureType;
 import no.digipost.signature.api.xml.XMLSigningOnBehalfOf;
@@ -59,6 +60,8 @@ public class CreateDirectManifest extends ManifestCreator<DirectJob> {
                         .withDescription(document.getMessage())
                         .withHref(document.getFileName())
                         .withMime(document.getMimeType())
-                );
+                )
+                .withIdentifierInSignedDocuments(job.getIdentifierInSignedDocuments().map(MarshallableEnum.To.<XMLIdentifierInSignedDocuments>xmlValue()).orNull())
+                ;
     }
 }

--- a/src/main/java/no/digipost/signature/client/asice/manifest/CreatePortalManifest.java
+++ b/src/main/java/no/digipost/signature/client/asice/manifest/CreatePortalManifest.java
@@ -19,6 +19,7 @@ import no.digipost.signature.api.xml.XMLAuthenticationLevel;
 import no.digipost.signature.api.xml.XMLAvailability;
 import no.digipost.signature.api.xml.XMLEmail;
 import no.digipost.signature.api.xml.XMLEnabled;
+import no.digipost.signature.api.xml.XMLIdentifierInSignedDocuments;
 import no.digipost.signature.api.xml.XMLNotifications;
 import no.digipost.signature.api.xml.XMLNotificationsUsingLookup;
 import no.digipost.signature.api.xml.XMLPortalDocument;
@@ -29,21 +30,17 @@ import no.digipost.signature.api.xml.XMLSignatureType;
 import no.digipost.signature.api.xml.XMLSigningOnBehalfOf;
 import no.digipost.signature.api.xml.XMLSms;
 import no.digipost.signature.client.core.Sender;
-import no.digipost.signature.client.core.exceptions.SignerNotSpecifiedException;
 import no.digipost.signature.client.core.internal.MarshallableEnum;
 import no.digipost.signature.client.portal.Notifications;
 import no.digipost.signature.client.portal.NotificationsUsingLookup;
 import no.digipost.signature.client.portal.PortalDocument;
 import no.digipost.signature.client.portal.PortalJob;
 import no.digipost.signature.client.portal.PortalSigner;
-import no.motif.f.Fn0;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import static no.digipost.signature.client.core.exceptions.SignerNotSpecifiedException.SIGNER_NOT_SPECIFIED;
-import static no.digipost.signature.client.core.internal.IdentifierType.EMAIL;
-import static no.digipost.signature.client.core.internal.IdentifierType.MOBILE_NUMBER;
 
 public class CreatePortalManifest extends ManifestCreator<PortalJob> {
 
@@ -76,7 +73,9 @@ public class CreatePortalManifest extends ManifestCreator<PortalJob> {
                 .withAvailability(new XMLAvailability()
                         .withActivationTime(job.getActivationTime())
                         .withAvailableSeconds(job.getAvailableSeconds())
-                );
+                )
+                .withIdentifierInSignedDocuments(job.getIdentifierInSignedDocuments().map(MarshallableEnum.To.<XMLIdentifierInSignedDocuments>xmlValue()).orNull())
+                ;
     }
 
     private XMLPortalSigner generateSigner(PortalSigner signer) {

--- a/src/main/java/no/digipost/signature/client/core/IdentifierInSignedDocuments.java
+++ b/src/main/java/no/digipost/signature/client/core/IdentifierInSignedDocuments.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) Posten Norge AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.signature.client.core;
+
+import no.digipost.signature.api.xml.XMLIdentifierInSignedDocuments;
+import no.digipost.signature.client.core.internal.MarshallableEnum;
+
+public enum IdentifierInSignedDocuments implements MarshallableEnum<XMLIdentifierInSignedDocuments> {
+
+    PERSONAL_IDENTIFICATION_NUMBER_AND_NAME(XMLIdentifierInSignedDocuments.PERSONAL_IDENTIFICATION_NUMBER_AND_NAME),
+    DATE_OF_BIRTH_AND_NAME(XMLIdentifierInSignedDocuments.DATE_OF_BIRTH_AND_NAME),
+    NAME(XMLIdentifierInSignedDocuments.NAME),
+    ;
+
+
+    private final XMLIdentifierInSignedDocuments xmlEnumValue;
+
+    IdentifierInSignedDocuments(XMLIdentifierInSignedDocuments xmlEnumValue) {
+        this.xmlEnumValue = xmlEnumValue;
+    }
+
+    @Override
+    public XMLIdentifierInSignedDocuments getXmlEnumValue() {
+        return xmlEnumValue;
+    }
+}

--- a/src/main/java/no/digipost/signature/client/core/SignatureJob.java
+++ b/src/main/java/no/digipost/signature/client/core/SignatureJob.java
@@ -27,4 +27,6 @@ public interface SignatureJob {
 
     Optional<AuthenticationLevel> getRequiredAuthentication();
 
+    Optional<IdentifierInSignedDocuments> getIdentifierInSignedDocuments();
+
 }

--- a/src/main/java/no/digipost/signature/client/core/internal/JobCustomizations.java
+++ b/src/main/java/no/digipost/signature/client/core/internal/JobCustomizations.java
@@ -16,6 +16,7 @@
 package no.digipost.signature.client.core.internal;
 
 import no.digipost.signature.client.core.AuthenticationLevel;
+import no.digipost.signature.client.core.IdentifierInSignedDocuments;
 import no.digipost.signature.client.core.Sender;
 
 import java.util.UUID;
@@ -43,7 +44,7 @@ public interface JobCustomizations<B extends JobCustomizations<B>> {
      * as it will limit which <em>authentication mechanisms offered at the time of signing</em>
      * the document.
      *
-     * @param level the required minimum {@link AuthenticationLevel}.
+     * @param minimumLevel the required minimum {@link AuthenticationLevel}.
      */
     B requireAuthentication(AuthenticationLevel minimumLevel);
 
@@ -62,5 +63,18 @@ public interface JobCustomizations<B extends JobCustomizations<B>> {
      * @param reference the reference
      */
     B withReference(String reference);
+
+    /**
+     *  Specify how the signer(s) of this job should be identified in the signed documents (XAdES and PAdES);
+     *  by {@link IdentifierInSignedDocuments#PERSONAL_IDENTIFICATION_NUMBER_AND_NAME personal identification number and name},
+     *  {@link IdentifierInSignedDocuments#DATE_OF_BIRTH_AND_NAME date of birth and name} or
+     *  {@link IdentifierInSignedDocuments#NAME name only}.
+     *  <p>
+     *  Not all options are available to every sender, this is detailed in the service's
+     *  <a href="https://digipost.github.io/signature-api-specification">functional documentation</a>.
+     *
+     * @param identifier the identifier type
+     */
+    B withIdentifierInSignedDocuments(IdentifierInSignedDocuments identifier);
 
 }

--- a/src/main/java/no/digipost/signature/client/direct/DirectJob.java
+++ b/src/main/java/no/digipost/signature/client/direct/DirectJob.java
@@ -16,6 +16,7 @@
 package no.digipost.signature.client.direct;
 
 import no.digipost.signature.client.core.AuthenticationLevel;
+import no.digipost.signature.client.core.IdentifierInSignedDocuments;
 import no.digipost.signature.client.core.Sender;
 import no.digipost.signature.client.core.SignatureJob;
 import no.digipost.signature.client.core.internal.JobCustomizations;
@@ -41,6 +42,7 @@ public class DirectJob implements SignatureJob, WithExitUrls {
     private Optional<Sender> sender = Singular.none();
     private Optional<StatusRetrievalMethod> statusRetrievalMethod = Singular.none();
     private Optional<AuthenticationLevel> requiredAuthentication = Singular.none();
+    private Optional<IdentifierInSignedDocuments> identifierInSignedDocuments = Singular.none();
 
     private DirectJob(List<DirectSigner> signers, DirectDocument document, String completionUrl, String rejectionUrl, String errorUrl) {
         this.signers = unmodifiableList(new ArrayList<>(signers));
@@ -83,6 +85,11 @@ public class DirectJob implements SignatureJob, WithExitUrls {
     @Override
     public Optional<AuthenticationLevel> getRequiredAuthentication() {
         return requiredAuthentication;
+    }
+
+    @Override
+    public Optional<IdentifierInSignedDocuments> getIdentifierInSignedDocuments() {
+        return identifierInSignedDocuments;
     }
 
     public List<DirectSigner> getSigners() {
@@ -155,6 +162,12 @@ public class DirectJob implements SignatureJob, WithExitUrls {
         @Override
         public Builder requireAuthentication(AuthenticationLevel level) {
             target.requiredAuthentication = optional(level);
+            return this;
+        }
+
+        @Override
+        public Builder withIdentifierInSignedDocuments(IdentifierInSignedDocuments identifier) {
+            target.identifierInSignedDocuments = optional(identifier);
             return this;
         }
 

--- a/src/main/java/no/digipost/signature/client/portal/PortalJob.java
+++ b/src/main/java/no/digipost/signature/client/portal/PortalJob.java
@@ -16,6 +16,7 @@
 package no.digipost.signature.client.portal;
 
 import no.digipost.signature.client.core.AuthenticationLevel;
+import no.digipost.signature.client.core.IdentifierInSignedDocuments;
 import no.digipost.signature.client.core.Sender;
 import no.digipost.signature.client.core.SignatureJob;
 import no.digipost.signature.client.core.internal.JobCustomizations;
@@ -42,6 +43,7 @@ public class PortalJob implements SignatureJob {
     private Long availableSeconds;
     private Optional<Sender> sender = Singular.none();
     private Optional<AuthenticationLevel> requiredAuthentication = Singular.none();
+    private Optional<IdentifierInSignedDocuments> identifierInSignedDocuments = Singular.none();
 
     private PortalJob(List<PortalSigner> signers, PortalDocument document) {
         this.signers = unmodifiableList(new ArrayList<>(signers));
@@ -66,6 +68,11 @@ public class PortalJob implements SignatureJob {
     @Override
     public Optional<AuthenticationLevel> getRequiredAuthentication() {
         return requiredAuthentication;
+    }
+
+    @Override
+    public Optional<IdentifierInSignedDocuments> getIdentifierInSignedDocuments() {
+        return identifierInSignedDocuments;
     }
 
     public List<PortalSigner> getSigners() {
@@ -118,6 +125,12 @@ public class PortalJob implements SignatureJob {
         @Override
         public Builder requireAuthentication(AuthenticationLevel minimumLevel) {
             target.requiredAuthentication = optional(minimumLevel);
+            return this;
+        }
+
+        @Override
+        public Builder withIdentifierInSignedDocuments(IdentifierInSignedDocuments identifier) {
+            target.identifierInSignedDocuments = optional(identifier);
             return this;
         }
 

--- a/src/test/java/no/digipost/signature/client/asice/CreateASiCETest.java
+++ b/src/test/java/no/digipost/signature/client/asice/CreateASiCETest.java
@@ -90,7 +90,7 @@ public class CreateASiCETest {
 
     @Test
     public void create_portal_asice_and_write_to_disk() throws IOException {
-        PortalJob job = PortalJob.builder(PORTAL_DOCUMENT, PortalSigner.builder("12345678910", NotificationsUsingLookup.EMAIL_ONLY).build())
+        PortalJob job = PortalJob.builder(PORTAL_DOCUMENT, PortalSigner.identifiedByPersonalIdentificationNumber("12345678910", NotificationsUsingLookup.EMAIL_ONLY).build())
                 .withReference("portal job")
                 .withActivationTime(new Date())
                 .availableFor(30, DAYS)

--- a/src/test/java/no/digipost/signature/client/asice/manifest/CreateDirectManifestTest.java
+++ b/src/test/java/no/digipost/signature/client/asice/manifest/CreateDirectManifestTest.java
@@ -16,6 +16,7 @@
 package no.digipost.signature.client.asice.manifest;
 
 import no.digipost.signature.client.core.Document;
+import no.digipost.signature.client.core.IdentifierInSignedDocuments;
 import no.digipost.signature.client.core.Sender;
 import no.digipost.signature.client.direct.DirectDocument;
 import no.digipost.signature.client.direct.DirectJob;
@@ -36,7 +37,9 @@ public class CreateDirectManifestTest {
                 .fileType(Document.FileType.TXT)
                 .build();
 
-        DirectJob job = DirectJob.builder(document, ExitUrls.of("http://localhost/signed", "http://localhost/canceled", "http://localhost/failed"), DirectSigner.withPersonalIdentificationNumber("12345678910").build()).build();
+        DirectJob job = DirectJob.builder(document, ExitUrls.of("http://localhost/signed", "http://localhost/canceled", "http://localhost/failed"), DirectSigner.withPersonalIdentificationNumber("12345678910").build())
+                .withIdentifierInSignedDocuments(IdentifierInSignedDocuments.NAME)
+                .build();
         try {
             createManifest.createManifest(job, new Sender("123456789"));
         } catch (Exception e) {

--- a/src/test/java/no/digipost/signature/client/asice/manifest/CreatePortalManifestTest.java
+++ b/src/test/java/no/digipost/signature/client/asice/manifest/CreatePortalManifestTest.java
@@ -16,6 +16,7 @@
 package no.digipost.signature.client.asice.manifest;
 
 import no.digipost.signature.client.core.Document;
+import no.digipost.signature.client.core.IdentifierInSignedDocuments;
 import no.digipost.signature.client.core.Sender;
 import no.digipost.signature.client.portal.NotificationsUsingLookup;
 import no.digipost.signature.client.portal.PortalDocument;
@@ -40,9 +41,10 @@ public class CreatePortalManifestTest {
                 .fileType(Document.FileType.TXT)
                 .build();
 
-        PortalJob job = PortalJob.builder(document, Collections.singletonList(PortalSigner.builder("12345678910", NotificationsUsingLookup.EMAIL_ONLY).build()))
+        PortalJob job = PortalJob.builder(document, Collections.singletonList(PortalSigner.identifiedByPersonalIdentificationNumber("12345678910", NotificationsUsingLookup.EMAIL_ONLY).build()))
                 .withActivationTime(new Date())
                 .availableFor(30, DAYS)
+                .withIdentifierInSignedDocuments(IdentifierInSignedDocuments.PERSONAL_IDENTIFICATION_NUMBER_AND_NAME)
                 .build();
         try {
             createManifest.createManifest(job, new Sender("123456789"));


### PR DESCRIPTION
Lar avsendere velge hvordan undertegnerene skal identifiseres i signerte dokumenter. 

Se også https://github.com/digipost/signature-api-specification/pull/68

For asynkrone oppdrag:
```java
PortalJob job = PortalJob.builder(document, Collections.singletonList(PortalSigner.identifiedByPersonalIdentificationNumber(…).build()))
        .withIdentifierInSignedDocuments(IdentifierInSignedDocuments.PERSONAL_IDENTIFICATION_NUMBER_AND_NAME)
        .build();
```

Synkrone oppdrag:
```java
DirectJob job = DirectJob.builder(document, ExitUrls.of(…), DirectSigner.withPersonalIdentificationNumber(…).build())
        .withIdentifierInSignedDocuments(IdentifierInSignedDocuments.NAME)
        .build();
```