### PR TITLE
Oppdatert et knippe avhengigheter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ cache:
 
 language: java
 jdk:
-  - openjdk7
   - oraclejdk8
 
 env:

--- a/NOTICE
+++ b/NOTICE
@@ -44,12 +44,12 @@ This software includes third party software subject to the following licenses:
   ServiceLocator Default Implementation under CDDL + GPLv2 with classpath exception
   SLF4J API Module under MIT License
   SLF4J Simple Binding under MIT License
-  Spring AOP under The Apache Software License, Version 2.0
-  Spring Beans under The Apache Software License, Version 2.0
-  Spring Context under The Apache Software License, Version 2.0
-  Spring Core under The Apache Software License, Version 2.0
-  Spring Expression Language (SpEL) under The Apache Software License, Version 2.0
-  Spring Object/XML Marshalling under The Apache Software License, Version 2.0
-  Spring XML under The Apache Software License, Version 2.0
+  Spring AOP under Apache License, Version 2.0
+  Spring Beans under Apache License, Version 2.0
+  Spring Context under Apache License, Version 2.0
+  Spring Core under Apache License, Version 2.0
+  Spring Expression Language (SpEL) under Apache License, Version 2.0
+  Spring Object/XML Marshalling under Apache License, Version 2.0
+  spring-xml under Apache License, Version 2.0
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,14 +25,14 @@
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-framework-bom</artifactId>
-                <version>4.3.4.RELEASE</version>
+                <version>4.3.12.RELEASE</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.jersey</groupId>
                 <artifactId>jersey-bom</artifactId>
-                <version>2.23.2</version>
+                <version>2.25.1</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.2</version>
+            <version>4.5.3</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>
@@ -65,17 +65,17 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
-            <version>4.4.5</version>
+            <version>4.4.8</version>
         </dependency>
         <dependency>
             <groupId>javax.annotation</groupId>
             <artifactId>javax.annotation-api</artifactId>
-            <version>1.2</version>
+            <version>1.3.1</version>
         </dependency>
         <dependency>
             <groupId>javax.ws.rs</groupId>
             <artifactId>javax.ws.rs-api</artifactId>
-            <version>2.0.1</version>
+            <version>2.1</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
@@ -92,13 +92,13 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.5</version>
+            <version>2.6</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.10</version>
+            <version>1.11</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
@@ -117,7 +117,7 @@
         <dependency>
             <groupId>org.springframework.ws</groupId>
             <artifactId>spring-xml</artifactId>
-            <version>2.4.0.RELEASE</version>
+            <version>2.4.1.RELEASE</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>
@@ -170,7 +170,7 @@
         <dependency>
             <groupId>nl.jqno.equalsverifier</groupId>
             <artifactId>equalsverifier</artifactId>
-            <version>2.1.7</version>
+            <version>2.3.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,8 @@
     </parent>
 
     <properties>
-        <maven.compiler.source>1.7</maven.compiler.source>
-        <maven.compiler.target>1.7</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
         <signature.api.version>1.9</signature.api.version>
         <slf4j.version>1.7.21</slf4j.version>
     </properties>

--- a/src/main/java/no/digipost/signature/client/core/internal/ClientHelper.java
+++ b/src/main/java/no/digipost/signature/client/core/internal/ClientHelper.java
@@ -48,7 +48,6 @@ import static no.digipost.signature.client.core.internal.ErrorCodes.BROKER_NOT_A
 import static no.digipost.signature.client.core.internal.ErrorCodes.SIGNING_CEREMONY_NOT_COMPLETED;
 import static no.digipost.signature.client.core.internal.Target.DIRECT;
 import static no.digipost.signature.client.core.internal.Target.PORTAL;
-import static no.digipost.signature.client.core.internal.http.ResponseStatus.Custom.TOO_MANY_REQUESTS;
 import static no.motif.Singular.optional;
 import static no.motif.Strings.nonblank;
 

--- a/src/main/java/no/digipost/signature/client/core/internal/http/ResponseStatus.java
+++ b/src/main/java/no/digipost/signature/client/core/internal/http/ResponseStatus.java
@@ -42,16 +42,12 @@ public class ResponseStatus {
     public enum Custom implements StatusType {
 
         /**
-         * 422 Unprocesable Entity, see
+         * 422 Unprocessable Entity, see
          * <a href="https://tools.ietf.org/html/rfc4918#section-11.2">https://tools.ietf.org/html/rfc4918#section-11.2</a>
          */
         UNPROCESSABLE_ENTITY(422, "Unprocessable Entity"),
 
-        /**
-         * 429 Too Many Requests, see
-         * <a href="https://tools.ietf.org/html/rfc6585#page-3">https://tools.ietf.org/html/rfc6585#page-3</a>
-         */
-        TOO_MANY_REQUESTS(429, "Too Many Requests");
+        ;
 
         /**
          * Convert a numerical status code into the corresponding CustomStatus.


### PR DESCRIPTION
Fjernet `TOO_MANY_REQUESTS` fra våre custom statustyper, ettersom denne
konstanten har blitt inkludert i `Response.Status` i `javax.ws.rs-api`
versjon 2.1