### PR TITLE
Java 8 🤘

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -12,6 +12,7 @@ This software includes third party software subject to the following licenses:
   aopalliance version 1.0 repackaged as a module under CDDL + GPLv2 with classpath exception
   Apache Commons Codec under Apache License, Version 2.0
   Apache Commons IO under Apache License, Version 2.0
+  Apache Commons Lang under Apache License, Version 2.0
   Apache HttpClient under Apache License, Version 2.0
   Apache HttpCore under Apache License, Version 2.0
   EqualsVerifier under The Apache Software License, Version 2.0
@@ -35,7 +36,6 @@ This software includes third party software subject to the following licenses:
   junit-quickcheck-generators under The MIT License
   junit-theories under Eclipse Public License v 1.0
   MIME streaming extension under CDDL 1.1 or GPL2 w/ CPE
-  Motif under Apache License 2.0
   OGNL - Object Graph Navigation Library under The Apache Software License, Version 2.0
   OSGi resource locator bundle - used by various API providers that rely on META-INF/services mechanism to locate providers. under CDDL + GPLv2 with classpath exception
   Posten signering - API JAXB Classes under The Apache Software License, Version 2.0

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Klientbiblioteket er releaset til [![Maven Central](https://maven-badges.herokua
 <dependency>
     <groupId>no.digipost.signature</groupId>
     <artifactId>signature-api-client-java</artifactId>
-    <version>2.2</version>
+    <version>3.0</version>
 </dependency>
 ```
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -11,8 +11,8 @@ licenseUrl: http://opensource.org/licenses/MIT
 
 baseurl: "/signature-api-client-java"
 
-currentVersion: "2.x"
-versions: ["2.x", "1.x"]
+currentVersion: "3.x"
+versions: ["3.x", "2.x", "1.x"]
 
 collections:
   v1_x:
@@ -21,6 +21,9 @@ collections:
   v2_x:
     output: true
     permalink: /v2.x/
+  v3_x:
+    output: true
+    permalink: /v3.x/
 
 # list of additional links on the right of the top menu
 headerLinks:

--- a/docs/_v3_x/1_setup.md
+++ b/docs/_v3_x/1_setup.md
@@ -10,10 +10,10 @@ The client library is available on [Maven Central](https://search.maven.org/#sea
 <dependency>
     <groupId>no.digipost.signature</groupId>
     <artifactId>signature-api-client-java</artifactId>
-    <version>2.4</version>
+    <version>3.0</version>
 </dependency>
 {% endhighlight %}
 
 #### Javadoc
 
-Javadoc is available here: [javadoc.io/doc/no.digipost.signature/signature-api-client-java](https://www.javadoc.io/doc/no.digipost.signature/signature-api-client-java/2.4)
+Javadoc is available here: [javadoc.io/doc/no.digipost.signature/signature-api-client-java](https://www.javadoc.io/doc/no.digipost.signature/signature-api-client-java/3.0)

--- a/docs/_v3_x/2_direct_usecases.md
+++ b/docs/_v3_x/2_direct_usecases.md
@@ -1,0 +1,119 @@
+---
+identifier: directusecases
+title: Direct use cases
+layout: default
+---
+
+<h3 id="uc01">Create client configuration</h3>
+
+{% highlight java %}
+
+KeyStoreConfig keyStoreConfig = KeyStoreConfig.fromKeyStore(keyStore,
+        certificateAlias, keyStorePassword, privateKeyPassword);
+
+ClientConfiguration clientConfiguration = ClientConfiguration.builder(keyStoreConfig)
+        .globalSender(new Sender("123456789"))
+        .build();
+
+{% endhighlight %}
+
+> Note: For organizations acting as *brokers* on behalf of multiple *senders*, you may specify the sender's organization number on each signature job. The sender specified for a job will always take precedence over the `globalSender` in `ClientConfiguration`
+
+<h3 id="uc02">Create and send signature job</h3>
+
+{% highlight java %}
+
+ClientConfiguration clientConfiguration = ...; // As initialized earlier
+DirectClient client = new DirectClient(clientConfiguration);
+
+byte[] documentBytes = ...;
+DirectDocument document = DirectDocument.builder("Subject", "document.pdf", documentBytes).build();
+
+ExitUrls exitUrls = ExitUrls.of(
+        "http://sender.org/onCompletion",
+        "http://sender.org/onRejection",
+        "http://sender.org/onError"
+);
+
+DirectSigner signer = DirectSigner.withPersonalIdentificationNumber("12345678910").build();
+DirectJob directJob = DirectJob.builder(document, exitUrls, signer).build();
+
+DirectJobResponse directJobResponse = client.create(directJob);
+
+{% endhighlight %}
+
+> Note: Most domain object follow the builder pattern, accepting all required parameters in the factory method and with specific methods for each optional parameter. Keep this in mind when exploring the API.
+
+<h3 id="uc03">Get signature job status</h3>
+
+The signing process is a synchrounous operation in the direct use case. There is no need to poll for changes to a signature job, as the status is well known to the sender of the job. As soon as the signer completes, rejects or an error occurs, the user is redirected to the respective URLs set in `ExitUrls`. A `status_query_token` parameter has been added to the url, use this when requesting a status change.
+
+{% highlight java %}
+
+DirectClient client = ...; // As initialized earlier
+DirectJobResponse directJobResponse = ...; // As returned when creating signature job
+
+String statusQueryToken = "0A3BQ54C…";
+
+DirectJobStatusResponse directJobStatusResponse =
+        client.getStatus(StatusReference.of(directJobResponse).withStatusQueryToken(statusQueryToken));
+
+{% endhighlight %}
+
+<h3 id="uc4">Get direct job status by polling</h3> 
+
+If you, for any reason, are unable to retrieve status by using the status query token specified above, you may poll the service for any changes done to your organization’s jobs. If the queue is empty, additional polling will give an exception.
+
+<blockquote>Note: For the job to be available in the polling queue, make sure to specify the job's <code>StatusRetrievalMethod</code> as illustrated below.</blockquote>
+
+{% highlight java %}
+DirectClient client = ...; // As initialized earlier
+
+DirectJob directJob = DirectJob.builder(document, exitUrls, signer)
+        .retrieveStatusBy(StatusRetrievalMethod.POLLING)
+        .build();
+
+client.create(directJob);
+
+DirectJobStatusResponse statusChange = client.getStatusChange();
+
+if (statusChange.is(DirectJobStatus.NO_CHANGES)) {
+    // Queue is empty. Must wait before polling again
+} else {
+    // Recieved status update, act according to status
+    DirectJobStatus status = statusChange.getStatus();
+}
+
+client.confirm(statusChange);
+
+{% endhighlight %}
+
+<h3 id="uc05">Get signed documents</h3>
+
+{% highlight java %}
+
+DirectClient client = ...; // As initialized earlier
+DirectJobStatusResponse directJobStatusResponse = ...; // As returned when getting job status
+
+if (directJobStatusResponse.isPAdESAvailable()) {
+    InputStream pAdESStream = client.getPAdES(directJobStatusResponse.getpAdESUrl());
+}
+
+for (Signature signature : directJobStatusResponse.getSignatures()) {
+    if (signature.is(SignerStatus.SIGNED)) {
+        InputStream xAdESStream = client.getXAdES(signature.getxAdESUrl());
+    }
+}
+
+{% endhighlight %}
+
+<h3 id="uc06">Confirm processed signature job</h3>
+
+{% highlight java %}
+
+DirectClient client = ...; // As initialized earlier
+DirectJobStatusResponse directJobStatusResponse = ...; // As returned when getting job status
+
+client.confirm(directJobStatusResponse);
+
+{% endhighlight %}

--- a/docs/_v3_x/3_portal_usecases.md
+++ b/docs/_v3_x/3_portal_usecases.md
@@ -1,0 +1,131 @@
+---
+identifier: portalusecases
+title: Portal use cases
+layout: default
+---
+
+<h3 id="uc07">Create Client Configuration</h3>
+
+{% highlight java %}
+
+KeyStoreConfig keyStoreConfig = KeyStoreConfig.fromKeyStore(keyStore,
+        certificateAlias, keyStorePassword, privateKeyPassword);
+
+ClientConfiguration clientConfiguration = ClientConfiguration.builder(keyStoreConfig)
+        .globalSender(new Sender("123456789"))
+        .build();
+
+{% endhighlight %}
+
+> Note: For organizations acting as *brokers* on behalf of multiple *senders*, you may specify the sender's organization number on each signature job. The sender specified for a job will always take precedence over the `globalSender` in `ClientConfiguration`
+
+<h3 id="uc08">Create and send signature job</h3>
+
+The following example shows how to create a document and send it to two signers.
+
+{% highlight java %}
+
+ClientConfiguration clientConfiguration = ...; // As initialized earlier
+PortalClient client = new PortalClient(clientConfiguration);
+
+byte[] documentBytes = ...;
+PortalDocument document = PortalDocument.builder("Subject", "document.pdf", documentBytes).build();
+
+PortalJob portalJob = PortalJob.builder(
+        document,
+        PortalSigner.identifiedByPersonalIdentificationNumber("12345678910",
+                NotificationsUsingLookup.EMAIL_ONLY).build(),
+        PortalSigner.identifiedByPersonalIdentificationNumber("12345678911",
+                Notifications.builder().withEmailTo("email@example.com").build()).build(),
+        PortalSigner.identifiedByEmail("email@example.com").build()
+).build();
+
+PortalJobResponse portalJobResponse = client.create(portalJob);
+
+{% endhighlight %}
+
+You may identify the signature job's signers by personal identification number (`identifiedByPersonalIdentificationNumber(…)`) or contact information. When identifying by contact information, you may choose between instantiating a `PortalSigner` using `identifiedByEmail(…)`, `identifiedByMobileNumber(…)` or `identifiedByEmailAndMobileNumber(…, …)`.
+
+Read more about identifying your signers in the [functional documentation](http://digipost.github.io/signature-api-specification/v1.0/#kontaktinfo) (Norwegian).
+
+> Note: Most domain object follow the builder pattern, accepting all required parameters in the factory method and with specific methods for each optional parameter. Keep this in mind when exploring the API.
+
+<h3 id="uc09">Get status changes</h3>
+
+All changes to signature jobs will be added to a queue from which you can poll for status updates. If the queue is empty (i.e. no jobs have changed status since last poll), you are not allowed to poll again for a defined period. Refer to the [API specification](https://github.com/digipost/signature-api-specification/blob/master/README.md#hvor-ofte-skal-du-polle) to see how long this period is.
+
+The following example shows how this can be handled:
+
+{% highlight java %}
+
+PortalClient client = ...; // As initialized earlier
+
+PortalJobStatusChanged statusChange = client.getStatusChange();
+
+if (statusChange.is(PortalJobStatus.NO_CHANGES)) {
+    // Queue is empty. Must wait before polling again
+} else {
+    // Recieved status update, act according to status
+    PortalJobStatus signatureJobStatus = statusChange.getStatus();
+}
+
+// Polling immediately after retrieving NO_CHANGES:
+try {
+    client.getStatusChange();
+} catch (TooEagerPollingException tooEagerPolling) {
+    Instant nextPermittedPollTime = tooEagerPolling.getNextPermittedPollTime();
+}
+
+{% endhighlight %}
+
+Retrieve a specific signer's status by calling the method `statusChange.getSignatureFrom(SignerIdentifier)`. The `SignerIdentifier` parameter must be created by using [one of the static method](https://javadoc.io/page/no.digipost.signature/signature-api-client-java/latest/no/digipost/signature/client/portal/SignerIdentifier.html) corresponding with the method you used when creating the signature job.
+
+{% highlight java %}
+
+Signature signature = statusChange.getSignatureFrom(
+    SignerIdentifier.identifiedByPersonalIdentificationNumber("12345678910"));
+
+{% endhighlight %}
+
+<h3 id="uc10">Get signed documents</h3>
+
+When getting XAdES and PAdES for a `PortalJob`, remember that the XAdES is per signer, while there is only one PAdES. 
+
+{% highlight java %}
+
+PortalClient client = ...; // As initialized earlier
+PortalJobStatusChanged statusChange = ...; // As returned when polling for status changes
+
+// Retrieve PAdES:
+if (statusChange.isPAdESAvailable()) {
+    InputStream pAdESStream = client.getPAdES(statusChange.getpAdESUrl());
+}
+
+// Retrieve XAdES for all signers:
+for (Signature signature : statusChange.getSignatures()) {
+    if (signature.is(SignatureStatus.SIGNED)) {
+        InputStream xAdESStream = client.getXAdES(signature.getxAdESUrl());
+    }
+}
+
+// … or for one specific signer:
+Signature signature = statusChange.getSignatureFrom(
+    SignerIdentifier.identifiedByPersonalIdentificationNumber("12345678910"));
+if (signature.is(SignatureStatus.SIGNED)) {
+    InputStream xAdESStream = client.getXAdES(signature.getxAdESUrl());
+}
+
+{% endhighlight %}
+
+<h3 id="uc11">Confirm processed signature job</h3>
+
+To avoid this status change to return to the queue, you must confirm that it has been processed.
+
+{% highlight java %}
+
+PortalClient client = ...; // As initialized earlier
+PortalJobStatusChanged statusChange = ...; // As returned when polling for status changes
+
+client.confirm(statusChange);
+
+{% endhighlight %}

--- a/docs/_v3_x/4_Error_Handling.md
+++ b/docs/_v3_x/4_Error_Handling.md
@@ -1,0 +1,28 @@
+---
+identifier: errorhandling
+title: Error Handling
+layout: default
+---
+
+<h3 id="errorHandlerHeader">Handling errors</h3>
+
+Different forms of exceptions may occur, some are more specific than others. All exceptions related to client behavior inherits from `SignatureException`. 
+
+{% highlight java %}
+
+try {
+    client.confirm(statusChange);
+} catch (BrokerNotAuthorizedException brokerNotAuthorized) {
+    // Broker is not authorized to perform action. Contact Difi in order to set up access rights.
+} catch (UnexpectedResponseException unexpectedResponse) {
+    // The server returned an unexpected response.
+    Response.StatusType httpStatusCode = unexpectedResponse.getActualStatus();
+
+    // errorCode and errorMesage will normally contain information returned by the server. May be null.
+    String errorCode = unexpectedResponse.getErrorCode();
+    String errorMessage = unexpectedResponse.getErrorMessage();
+} catch (SignatureException e) {
+    // An unexpected exception was thrown, inspect e.getMessage().
+}
+
+{% endhighlight %}

--- a/docs/_v3_x/5_Debugging.md
+++ b/docs/_v3_x/5_Debugging.md
@@ -1,0 +1,24 @@
+---
+identifier: Debugging
+title: Debugging
+layout: default
+---
+
+
+<h3 id="loggingrequestflow">Logging request and response</h3>
+
+> Warning: Enabling request logging should never be used in a production system. It will impact the performance of the client.	
+
+You may configure the client library to log HTTP requests and responses by calling `.enableRequestAndResponseLogging()` when creating the [client's configuration](#uc01). You may configure the logger `no.digipost.signature.client.http.requestresponse` in order to customize logging. It must be set to at least `INFO` to write anything to the log.
+
+
+<h3 id="loggingdocumentbundle">Writing document bundle to disk</h3>
+
+You may configure the client library to write a ZIP file with the document bundle by calling `.enableDocumentBundleDiskDump(Path)` when creating the [client's configuration](#uc01).
+
+The [Path](https://docs.oracle.com/javase/7/docs/api/java/nio/file/Path.html) parameter is the directory to where the files will be written. This directory *must* exists as the client library won't try creating it.
+
+If you have needs for the document bundle other than just saving it to disk, add your own document bundle processor by calling `.addDocumentBundleProcessor(…)` with your own `DocumentBundleProcessor` when creating the [client's configuration](#uc01).
+
+
+

--- a/docs/_v3_x/index.html
+++ b/docs/_v3_x/index.html
@@ -1,0 +1,14 @@
+---
+identifier: index
+layout: default
+redirect_from: /
+---
+
+{% for dok in site.v3_x %}
+	{% if dok.identifier != 'index' %}
+		<section class="bs-docs-section">  
+	  		<h1 id="{{ dok.identifier }}" class="page-header">{{ dok.title}}</h1>
+	  		{{dok.content}}  
+		</section>
+	{% endif%}
+{% endfor %}

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <signature.api.version>1.9</signature.api.version>
+        <signature.api.version>2.0-SNAPSHOT</signature.api.version>
         <slf4j.version>1.7.21</slf4j.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <name>Posten signering - Java API Client Library</name>
     <groupId>no.digipost.signature</groupId>
     <artifactId>signature-api-client-java</artifactId>
-    <version>3.0-SNAPSHOT</version>
+    <version>3.0</version>
 
     <parent>
         <groupId>no.digipost</groupId>
@@ -446,7 +446,7 @@
         <connection>scm:git:git@github.com:digipost/signature-api-client-java.git</connection>
         <developerConnection>scm:git:git@github.com:digipost/signature-api-client-java.git</developerConnection>
         <url>https://github.com/digipost/signature-api-client-java/</url>
-        <tag>HEAD</tag>
+        <tag>3.0</tag>
     </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <name>Posten signering - Java API Client Library</name>
     <groupId>no.digipost.signature</groupId>
     <artifactId>signature-api-client-java</artifactId>
-    <version>3.0</version>
+    <version>3.1-SNAPSHOT</version>
 
     <parent>
         <groupId>no.digipost</groupId>
@@ -446,7 +446,7 @@
         <connection>scm:git:git@github.com:digipost/signature-api-client-java.git</connection>
         <developerConnection>scm:git:git@github.com:digipost/signature-api-client-java.git</developerConnection>
         <url>https://github.com/digipost/signature-api-client-java/</url>
-        <tag>3.0</tag>
+        <tag>HEAD</tag>
     </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <signature.api.version>2.0-SNAPSHOT</signature.api.version>
+        <signature.api.version>2.0</signature.api.version>
         <slf4j.version>1.7.21</slf4j.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <name>Posten signering - Java API Client Library</name>
     <groupId>no.digipost.signature</groupId>
     <artifactId>signature-api-client-java</artifactId>
-    <version>2.5-SNAPSHOT</version>
+    <version>3.0-SNAPSHOT</version>
 
     <parent>
         <groupId>no.digipost</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -126,9 +126,9 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>com.github.runeflobakk</groupId>
-            <artifactId>motif</artifactId>
-            <version>0.8</version>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.6</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/no/digipost/signature/client/Certificates.java
+++ b/src/main/java/no/digipost/signature/client/Certificates.java
@@ -15,11 +15,11 @@
  */
 package no.digipost.signature.client;
 
-import no.motif.f.Fn;
-
 import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Stream;
 
-import static no.motif.Iterate.on;
+import static java.util.stream.Collectors.toList;
 
 public enum Certificates {
 
@@ -40,27 +40,19 @@ public enum Certificates {
     final List<String> certificatePaths;
 
     Certificates(String ... certificatePaths) {
-        this.certificatePaths = on(certificatePaths).map(FullCertificateClassPathUri.instance).collect();
+        this.certificatePaths = Stream.of(certificatePaths).map(FullCertificateClassPathUri.instance).collect(toList());
     }
 
-    static final Fn<Certificates, List<String>> getCertificatePaths = new Fn<Certificates, List<String>>() {
-        @Override
-        public List<String> $(Certificates certificates) {
-            return certificates.certificatePaths;
-        }
-    };
 }
 
 
-
-
-final class FullCertificateClassPathUri implements Fn<String, String> {
+final class FullCertificateClassPathUri implements Function<String, String> {
     static final FullCertificateClassPathUri instance = new FullCertificateClassPathUri();
 
     private static final String root = "/" + Certificates.class.getPackage().getName().replace('.', '/') + "/certificates/";
 
     @Override
-    public String $(String resourceName) {
+    public String apply(String resourceName) {
         return "classpath:" + root + resourceName;
     }
 }

--- a/src/main/java/no/digipost/signature/client/ClientMetadata.java
+++ b/src/main/java/no/digipost/signature/client/ClientMetadata.java
@@ -22,9 +22,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Scanner;
 
-public final class ClientMetadata {
+final class ClientMetadata {
 
-    public static final String VERSION;
+    static final String VERSION;
 
 
     static {

--- a/src/main/java/no/digipost/signature/client/asice/ASiCEConfiguration.java
+++ b/src/main/java/no/digipost/signature/client/asice/ASiCEConfiguration.java
@@ -17,7 +17,8 @@ package no.digipost.signature.client.asice;
 
 import no.digipost.signature.client.core.Sender;
 import no.digipost.signature.client.security.KeyStoreConfig;
-import no.motif.single.Optional;
+
+import java.util.Optional;
 
 public interface ASiCEConfiguration {
 

--- a/src/main/java/no/digipost/signature/client/asice/ASiCEConfiguration.java
+++ b/src/main/java/no/digipost/signature/client/asice/ASiCEConfiguration.java
@@ -18,6 +18,7 @@ package no.digipost.signature.client.asice;
 import no.digipost.signature.client.core.Sender;
 import no.digipost.signature.client.security.KeyStoreConfig;
 
+import java.time.Clock;
 import java.util.Optional;
 
 public interface ASiCEConfiguration {
@@ -27,5 +28,7 @@ public interface ASiCEConfiguration {
     Optional<Sender> getGlobalSender();
 
     Iterable<DocumentBundleProcessor> getDocumentBundleProcessors();
+
+    Clock getClock();
 
 }

--- a/src/main/java/no/digipost/signature/client/asice/CreateASiCE.java
+++ b/src/main/java/no/digipost/signature/client/asice/CreateASiCE.java
@@ -24,12 +24,12 @@ import no.digipost.signature.client.core.Sender;
 import no.digipost.signature.client.core.SignatureJob;
 import no.digipost.signature.client.core.exceptions.RuntimeIOException;
 import no.digipost.signature.client.security.KeyStoreConfig;
-import no.motif.single.Optional;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import static no.digipost.signature.client.core.exceptions.SenderNotSpecifiedException.SENDER_NOT_SPECIFIED;
 
@@ -52,8 +52,8 @@ public class CreateASiCE<JOB extends SignatureJob> {
 
     public DocumentBundle createASiCE(JOB job) {
         Sender sender = job.getSender()
-                .or(globalSender)
-                .orElseThrow(SENDER_NOT_SPECIFIED);
+                .orElse(globalSender
+                .orElseThrow(SENDER_NOT_SPECIFIED));
 
         Manifest manifest = manifestCreator.createManifest(job, sender);
 

--- a/src/main/java/no/digipost/signature/client/asice/CreateASiCE.java
+++ b/src/main/java/no/digipost/signature/client/asice/CreateASiCE.java
@@ -36,7 +36,7 @@ import static no.digipost.signature.client.core.exceptions.SenderNotSpecifiedExc
 public class CreateASiCE<JOB extends SignatureJob> {
 
     private final CreateZip createZip = new CreateZip();
-    private final CreateSignature createSignature = new CreateSignature();
+    private final CreateSignature createSignature;
 
     private final ManifestCreator<JOB> manifestCreator;
     private final Optional<Sender> globalSender;
@@ -48,6 +48,7 @@ public class CreateASiCE<JOB extends SignatureJob> {
         this.globalSender = clientConfiguration.getGlobalSender();
         this.keyStoreConfig = clientConfiguration.getKeyStoreConfig();
         this.documentBundleProcessors = clientConfiguration.getDocumentBundleProcessors();
+        this.createSignature = new CreateSignature(clientConfiguration.getClock());
     }
 
     public DocumentBundle createASiCE(JOB job) {

--- a/src/main/java/no/digipost/signature/client/asice/DumpDocumentBundleToDisk.java
+++ b/src/main/java/no/digipost/signature/client/asice/DumpDocumentBundleToDisk.java
@@ -16,8 +16,6 @@
 package no.digipost.signature.client.asice;
 
 import no.digipost.signature.client.core.SignatureJob;
-import no.motif.f.Fn;
-import no.motif.single.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,12 +26,11 @@ import java.nio.file.Path;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Optional;
+import java.util.function.Function;
 
+import static java.lang.String.format;
 import static java.nio.file.Files.isDirectory;
-import static no.motif.Base.first;
-import static no.motif.Singular.optional;
-import static no.motif.Strings.append;
-import static no.motif.Strings.inBetween;
 
 public class DumpDocumentBundleToDisk implements DocumentBundleProcessor {
 
@@ -52,10 +49,10 @@ public class DumpDocumentBundleToDisk implements DocumentBundleProcessor {
     public void process(SignatureJob job, InputStream documentBundle) throws IOException {
         if (isDirectory(directory)) {
             DateFormat timestampFormat = new SimpleDateFormat(TIMESTAMP_PATTERN);
-            Optional<String> reference = optional(job.getReference());
+            Optional<String> reference = Optional.ofNullable(job.getReference());
             String filename = timestampFormat.format(new Date()) + "-" + reference.map(referenceFilenamePart).orElse("") + "asice.zip";
             Path target = directory.resolve(filename);
-            LOG.info("Dumping document bundle{}to {}", reference.map(inBetween(" for job with reference '", "' ")).orElse(" "), target);
+            LOG.info("Dumping document bundle{}to {}", reference.map(ref -> format(" for job with reference '%s' ", ref)).orElse(" "), target);
             Files.copy(documentBundle, target);
         } else {
             throw new InvalidDirectoryException(directory);
@@ -68,11 +65,6 @@ public class DumpDocumentBundleToDisk implements DocumentBundleProcessor {
         }
     }
 
-    static final Fn<String, String> referenceFilenamePart = first(new Fn<String, String>() {
-        @Override
-        public String $(String reference) {
-            return reference.replace(' ', '_');
-        }
-    }).then(append("-"));
+    static final Function<String, String> referenceFilenamePart = reference -> reference.replace(' ', '_') + "-";
 
 }

--- a/src/main/java/no/digipost/signature/client/asice/manifest/CreateDirectManifest.java
+++ b/src/main/java/no/digipost/signature/client/asice/manifest/CreateDirectManifest.java
@@ -15,16 +15,15 @@
  */
 package no.digipost.signature.client.asice.manifest;
 
-import no.digipost.signature.api.xml.XMLAuthenticationLevel;
 import no.digipost.signature.api.xml.XMLDirectDocument;
 import no.digipost.signature.api.xml.XMLDirectSignatureJobManifest;
 import no.digipost.signature.api.xml.XMLDirectSigner;
-import no.digipost.signature.api.xml.XMLIdentifierInSignedDocuments;
 import no.digipost.signature.api.xml.XMLSender;
-import no.digipost.signature.api.xml.XMLSignatureType;
-import no.digipost.signature.api.xml.XMLSigningOnBehalfOf;
+import no.digipost.signature.client.core.AuthenticationLevel;
+import no.digipost.signature.client.core.IdentifierInSignedDocuments;
+import no.digipost.signature.client.core.OnBehalfOf;
 import no.digipost.signature.client.core.Sender;
-import no.digipost.signature.client.core.internal.MarshallableEnum;
+import no.digipost.signature.client.core.SignatureType;
 import no.digipost.signature.client.direct.DirectDocument;
 import no.digipost.signature.client.direct.DirectJob;
 import no.digipost.signature.client.direct.DirectSigner;
@@ -41,8 +40,8 @@ public class CreateDirectManifest extends ManifestCreator<DirectJob> {
         List<XMLDirectSigner> signers = new ArrayList<>();
         for (DirectSigner signer : job.getSigners()) {
             XMLDirectSigner xmlSigner = new XMLDirectSigner()
-                    .withSignatureType(signer.getSignatureType().map(MarshallableEnum.To.<XMLSignatureType>xmlValue()).orNull())
-                    .withOnBehalfOf(signer.getOnBehalfOf().map(MarshallableEnum.To.<XMLSigningOnBehalfOf>xmlValue()).orNull());
+                    .withSignatureType(signer.getSignatureType().map(SignatureType::getXmlEnumValue).orElse(null))
+                    .withOnBehalfOf(signer.getOnBehalfOf().map(OnBehalfOf::getXmlEnumValue).orElse(null));
             if (signer.isIdentifiedByPersonalIdentificationNumber()) {
                 xmlSigner.setPersonalIdentificationNumber(signer.getPersonalIdentificationNumber());
             } else {
@@ -53,7 +52,7 @@ public class CreateDirectManifest extends ManifestCreator<DirectJob> {
 
         return new XMLDirectSignatureJobManifest()
                 .withSigners(signers)
-                .withRequiredAuthentication(job.getRequiredAuthentication().map(MarshallableEnum.To.<XMLAuthenticationLevel>xmlValue()).orNull())
+                .withRequiredAuthentication(job.getRequiredAuthentication().map(AuthenticationLevel::getXmlEnumValue).orElse(null))
                 .withSender(new XMLSender().withOrganizationNumber(sender.getOrganizationNumber()))
                 .withDocument(new XMLDirectDocument()
                         .withTitle(document.getTitle())
@@ -61,7 +60,7 @@ public class CreateDirectManifest extends ManifestCreator<DirectJob> {
                         .withHref(document.getFileName())
                         .withMime(document.getMimeType())
                 )
-                .withIdentifierInSignedDocuments(job.getIdentifierInSignedDocuments().map(MarshallableEnum.To.<XMLIdentifierInSignedDocuments>xmlValue()).orNull())
+                .withIdentifierInSignedDocuments(job.getIdentifierInSignedDocuments().map(IdentifierInSignedDocuments::getXmlEnumValue).orElse(null))
                 ;
     }
 }

--- a/src/main/java/no/digipost/signature/client/asice/manifest/CreatePortalManifest.java
+++ b/src/main/java/no/digipost/signature/client/asice/manifest/CreatePortalManifest.java
@@ -15,22 +15,21 @@
  */
 package no.digipost.signature.client.asice.manifest;
 
-import no.digipost.signature.api.xml.XMLAuthenticationLevel;
 import no.digipost.signature.api.xml.XMLAvailability;
 import no.digipost.signature.api.xml.XMLEmail;
 import no.digipost.signature.api.xml.XMLEnabled;
-import no.digipost.signature.api.xml.XMLIdentifierInSignedDocuments;
 import no.digipost.signature.api.xml.XMLNotifications;
 import no.digipost.signature.api.xml.XMLNotificationsUsingLookup;
 import no.digipost.signature.api.xml.XMLPortalDocument;
 import no.digipost.signature.api.xml.XMLPortalSignatureJobManifest;
 import no.digipost.signature.api.xml.XMLPortalSigner;
 import no.digipost.signature.api.xml.XMLSender;
-import no.digipost.signature.api.xml.XMLSignatureType;
-import no.digipost.signature.api.xml.XMLSigningOnBehalfOf;
 import no.digipost.signature.api.xml.XMLSms;
+import no.digipost.signature.client.core.AuthenticationLevel;
+import no.digipost.signature.client.core.IdentifierInSignedDocuments;
+import no.digipost.signature.client.core.OnBehalfOf;
 import no.digipost.signature.client.core.Sender;
-import no.digipost.signature.client.core.internal.MarshallableEnum;
+import no.digipost.signature.client.core.SignatureType;
 import no.digipost.signature.client.portal.Notifications;
 import no.digipost.signature.client.portal.NotificationsUsingLookup;
 import no.digipost.signature.client.portal.PortalDocument;
@@ -61,7 +60,7 @@ public class CreatePortalManifest extends ManifestCreator<PortalJob> {
         PortalDocument document = job.getDocument();
         return new XMLPortalSignatureJobManifest()
                 .withSigners(xmlSigners)
-                .withRequiredAuthentication(job.getRequiredAuthentication().map(MarshallableEnum.To.<XMLAuthenticationLevel>xmlValue()).orNull())
+                .withRequiredAuthentication(job.getRequiredAuthentication().map(AuthenticationLevel::getXmlEnumValue).orElse(null))
                 .withSender(new XMLSender().withOrganizationNumber(sender.getOrganizationNumber()))
                 .withDocument(new XMLPortalDocument()
                         .withTitle(document.getTitle())
@@ -74,15 +73,15 @@ public class CreatePortalManifest extends ManifestCreator<PortalJob> {
                         .withActivationTime(job.getActivationTime())
                         .withAvailableSeconds(job.getAvailableSeconds())
                 )
-                .withIdentifierInSignedDocuments(job.getIdentifierInSignedDocuments().map(MarshallableEnum.To.<XMLIdentifierInSignedDocuments>xmlValue()).orNull())
+                .withIdentifierInSignedDocuments(job.getIdentifierInSignedDocuments().map(IdentifierInSignedDocuments::getXmlEnumValue).orElse(null))
                 ;
     }
 
     private XMLPortalSigner generateSigner(PortalSigner signer) {
         XMLPortalSigner xmlSigner = new XMLPortalSigner()
                 .withOrder(signer.getOrder())
-                .withSignatureType(signer.getSignatureType().map(MarshallableEnum.To.<XMLSignatureType>xmlValue()).orNull())
-                .withOnBehalfOf(signer.getOnBehalfOf().map(MarshallableEnum.To.<XMLSigningOnBehalfOf>xmlValue()).orNull());
+                .withSignatureType(signer.getSignatureType().map(SignatureType::getXmlEnumValue).orElse(null))
+                .withOnBehalfOf(signer.getOnBehalfOf().map(OnBehalfOf::getXmlEnumValue).orElse(null));
 
         if (signer.isIdentifiedByPersonalIdentificationNumber()) {
             xmlSigner.setPersonalIdentificationNumber(signer.getIdentifier().orElseThrow(SIGNER_NOT_SPECIFIED));

--- a/src/main/java/no/digipost/signature/client/asice/manifest/CreatePortalManifest.java
+++ b/src/main/java/no/digipost/signature/client/asice/manifest/CreatePortalManifest.java
@@ -36,12 +36,20 @@ import no.digipost.signature.client.portal.PortalDocument;
 import no.digipost.signature.client.portal.PortalJob;
 import no.digipost.signature.client.portal.PortalSigner;
 
+import java.time.Clock;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
 import static no.digipost.signature.client.core.exceptions.SignerNotSpecifiedException.SIGNER_NOT_SPECIFIED;
 
 public class CreatePortalManifest extends ManifestCreator<PortalJob> {
+
+    private final Clock clock;
+
+    public CreatePortalManifest(Clock clock) {
+        this.clock = clock;
+    }
 
     @Override
     Object buildXmlManifest(PortalJob job, Sender sender) {
@@ -58,6 +66,9 @@ public class CreatePortalManifest extends ManifestCreator<PortalJob> {
         }
 
         PortalDocument document = job.getDocument();
+
+        ZonedDateTime activationTime = job.getActivationTime().map(activation -> activation.atZone(clock.getZone())).orElse(null);
+
         return new XMLPortalSignatureJobManifest()
                 .withSigners(xmlSigners)
                 .withRequiredAuthentication(job.getRequiredAuthentication().map(AuthenticationLevel::getXmlEnumValue).orElse(null))
@@ -70,7 +81,7 @@ public class CreatePortalManifest extends ManifestCreator<PortalJob> {
                         .withMime(document.getMimeType())
                 )
                 .withAvailability(new XMLAvailability()
-                        .withActivationTime(job.getActivationTime())
+                        .withActivationTime(activationTime)
                         .withAvailableSeconds(job.getAvailableSeconds())
                 )
                 .withIdentifierInSignedDocuments(job.getIdentifierInSignedDocuments().map(IdentifierInSignedDocuments::getXmlEnumValue).orElse(null))

--- a/src/main/java/no/digipost/signature/client/asice/signature/CreateSignature.java
+++ b/src/main/java/no/digipost/signature/client/asice/signature/CreateSignature.java
@@ -64,6 +64,7 @@ import java.security.InvalidAlgorithmParameterException;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
 import java.security.cert.Certificate;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -88,9 +89,9 @@ public class CreateSignature {
     private final TransformerFactory transformerFactory;
     private final Schema schema;
 
-    public CreateSignature() {
+    public CreateSignature(Clock clock) {
 
-        createXAdESProperties = new CreateXAdESProperties();
+        createXAdESProperties = new CreateXAdESProperties(clock);
 
         transformerFactory = TransformerFactory.newInstance();
         try {

--- a/src/main/java/no/digipost/signature/client/asice/signature/CreateXAdESProperties.java
+++ b/src/main/java/no/digipost/signature/client/asice/signature/CreateXAdESProperties.java
@@ -15,12 +15,19 @@
  */
 package no.digipost.signature.client.asice.signature;
 
+import no.digipost.signature.api.xml.thirdparty.xades.CertIDType;
+import no.digipost.signature.api.xml.thirdparty.xades.DataObjectFormat;
+import no.digipost.signature.api.xml.thirdparty.xades.DigestAlgAndValueType;
+import no.digipost.signature.api.xml.thirdparty.xades.QualifyingProperties;
+import no.digipost.signature.api.xml.thirdparty.xades.SignedDataObjectProperties;
+import no.digipost.signature.api.xml.thirdparty.xades.SignedProperties;
+import no.digipost.signature.api.xml.thirdparty.xades.SignedSignatureProperties;
+import no.digipost.signature.api.xml.thirdparty.xades.SigningCertificate;
+import no.digipost.signature.api.xml.thirdparty.xmldsig.DigestMethod;
+import no.digipost.signature.api.xml.thirdparty.xmldsig.X509IssuerSerialType;
 import no.digipost.signature.client.asice.ASiCEAttachable;
 import no.digipost.signature.client.core.exceptions.CertificateException;
 import no.digipost.signature.client.core.exceptions.XmlConfigurationException;
-import no.digipost.signature.api.xml.thirdparty.xades.*;
-import no.digipost.signature.api.xml.thirdparty.xmldsig.DigestMethod;
-import no.digipost.signature.api.xml.thirdparty.xmldsig.X509IssuerSerialType;
 import org.springframework.oxm.jaxb.Jaxb2Marshaller;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -32,8 +39,9 @@ import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
+import java.time.Clock;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 
 import static java.lang.String.format;
@@ -42,9 +50,10 @@ import static java.util.Collections.singletonList;
 import static javax.xml.crypto.dsig.DigestMethod.SHA1;
 import static org.apache.commons.codec.digest.DigestUtils.sha1;
 
-public class CreateXAdESProperties {
+class CreateXAdESProperties {
 
     private final DigestMethod sha1DigestMethod = new DigestMethod(emptyList(), SHA1);
+    private final Clock clock;
 
     private static Jaxb2Marshaller marshaller;
 
@@ -53,7 +62,11 @@ public class CreateXAdESProperties {
         marshaller.setClassesToBeBound(QualifyingProperties.class);
     }
 
-    public Document createPropertiesToSign(final List<ASiCEAttachable> files, final X509Certificate certificate) {
+    CreateXAdESProperties(Clock clock) {
+        this.clock = clock;
+    }
+
+    Document createPropertiesToSign(final List<ASiCEAttachable> files, final X509Certificate certificate) {
         byte[] certificateDigestValue;
         try {
             certificateDigestValue = sha1(certificate.getEncoded());
@@ -65,7 +78,7 @@ public class CreateXAdESProperties {
         X509IssuerSerialType certificateIssuer = new X509IssuerSerialType(certificate.getIssuerDN().getName(), certificate.getSerialNumber());
         SigningCertificate signingCertificate = new SigningCertificate(singletonList(new CertIDType(certificateDigest, certificateIssuer, null)));
 
-        Date now = new Date();
+        ZonedDateTime now = ZonedDateTime.now(clock);
         SignedSignatureProperties signedSignatureProperties = new SignedSignatureProperties(now, signingCertificate, null, null, null, null);
         SignedDataObjectProperties signedDataObjectProperties = new SignedDataObjectProperties(dataObjectFormats(files), null, null, null, null);
         SignedProperties signedProperties = new SignedProperties(signedSignatureProperties, signedDataObjectProperties, "SignedProperties");

--- a/src/main/java/no/digipost/signature/client/core/AuthenticationLevel.java
+++ b/src/main/java/no/digipost/signature/client/core/AuthenticationLevel.java
@@ -30,7 +30,7 @@ public enum AuthenticationLevel implements MarshallableEnum<XMLAuthenticationLev
         return xmlEnumValue;
     }
 
-    private AuthenticationLevel(XMLAuthenticationLevel xmlEnumValue) {
+    AuthenticationLevel(XMLAuthenticationLevel xmlEnumValue) {
         this.xmlEnumValue = xmlEnumValue;
     }
 

--- a/src/main/java/no/digipost/signature/client/core/SignatureJob.java
+++ b/src/main/java/no/digipost/signature/client/core/SignatureJob.java
@@ -15,7 +15,7 @@
  */
 package no.digipost.signature.client.core;
 
-import no.motif.single.Optional;
+import java.util.Optional;
 
 public interface SignatureJob {
 

--- a/src/main/java/no/digipost/signature/client/core/SignatureType.java
+++ b/src/main/java/no/digipost/signature/client/core/SignatureType.java
@@ -28,7 +28,7 @@ public enum SignatureType implements MarshallableEnum<XMLSignatureType> {
 
     private final XMLSignatureType xmlEnumValue;
 
-    private SignatureType(XMLSignatureType xmlEnumValue) {
+    SignatureType(XMLSignatureType xmlEnumValue) {
         this.xmlEnumValue = xmlEnumValue;
     }
 

--- a/src/main/java/no/digipost/signature/client/core/exceptions/SenderNotSpecifiedException.java
+++ b/src/main/java/no/digipost/signature/client/core/exceptions/SenderNotSpecifiedException.java
@@ -15,18 +15,13 @@
  */
 package no.digipost.signature.client.core.exceptions;
 
-import no.motif.f.Fn0;
+import java.util.function.Supplier;
 
 public class SenderNotSpecifiedException extends SignatureException {
 
-    public static final Fn0<SignatureException> SENDER_NOT_SPECIFIED = new Fn0<SignatureException>() {
-        @Override
-        public SignatureException $() {
-            return new SenderNotSpecifiedException();
-        }
-    };
+    public static final Supplier<SignatureException> SENDER_NOT_SPECIFIED = SenderNotSpecifiedException::new;
 
-    public SenderNotSpecifiedException() {
+    private SenderNotSpecifiedException() {
         super("Sender is not specified. Please call ClientConfiguration#sender to set it globally, " +
                 "or DirectJob.Builder#withSender or PortalJob.Builder#withSender if you need to specify sender " +
                 "on a per job basis (typically when acting as a broker on behalf of multiple senders).");

--- a/src/main/java/no/digipost/signature/client/core/exceptions/SignerNotSpecifiedException.java
+++ b/src/main/java/no/digipost/signature/client/core/exceptions/SignerNotSpecifiedException.java
@@ -15,16 +15,11 @@
  */
 package no.digipost.signature.client.core.exceptions;
 
-import no.motif.f.Fn0;
+import java.util.function.Supplier;
 
 public class SignerNotSpecifiedException extends SignatureException {
 
-    public static final Fn0<SignatureException> SIGNER_NOT_SPECIFIED = new Fn0<SignatureException>() {
-        @Override
-        public SignatureException $() {
-            return new SignerNotSpecifiedException();
-        }
-    };
+    public static final Supplier<SignatureException> SIGNER_NOT_SPECIFIED = SignerNotSpecifiedException::new;
 
     private SignerNotSpecifiedException() {
         super("Signer's personal identification number must be specified.");

--- a/src/main/java/no/digipost/signature/client/core/exceptions/TooEagerPollingException.java
+++ b/src/main/java/no/digipost/signature/client/core/exceptions/TooEagerPollingException.java
@@ -15,25 +15,20 @@
  */
 package no.digipost.signature.client.core.exceptions;
 
-import java.text.DateFormat;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.Instant;
+import java.time.ZonedDateTime;
+
+import static java.time.format.DateTimeFormatter.ISO_DATE_TIME;
 
 public class TooEagerPollingException extends RuntimeException {
 
-    private final Date nextPermittedPollTime;
+    private final Instant nextPermittedPollTime;
 
     public TooEagerPollingException(String nextPermittedPollTime) {
-        DateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSX");
-        try {
-            this.nextPermittedPollTime = formatter.parse(nextPermittedPollTime);
-        } catch (ParseException e) {
-            throw new RuntimeException();
-        }
+        this.nextPermittedPollTime = ZonedDateTime.parse(nextPermittedPollTime, ISO_DATE_TIME).toInstant();
     }
 
-    public Date getNextPermittedPollTime() {
+    public Instant getNextPermittedPollTime() {
         return nextPermittedPollTime;
     }
 }

--- a/src/main/java/no/digipost/signature/client/core/internal/ClientExceptionMapper.java
+++ b/src/main/java/no/digipost/signature/client/core/internal/ClientExceptionMapper.java
@@ -21,27 +21,22 @@ import no.digipost.signature.client.core.exceptions.SignatureException;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
 import javax.ws.rs.ProcessingException;
-import java.util.concurrent.Callable;
+import java.util.function.Supplier;
 
 class ClientExceptionMapper {
 
-    public void doWithMappedClientException(final Runnable action) {
-        doWithMappedClientException(new Callable<Void>() {
-            @Override
-            public Void call() {
-                action.run();
-                return null;
-            }
+    void doWithMappedClientException(Runnable action) {
+        doWithMappedClientException(() -> {
+            action.run();
+            return null;
         });
     }
 
-    public <T> T doWithMappedClientException(Callable<T> produceResult) {
+    <T> T doWithMappedClientException(Supplier<T> produceResult) {
         try {
-            return produceResult.call();
+            return produceResult.get();
         } catch (ProcessingException e) {
             throw map(e);
-        } catch (Exception e) {
-            throw e instanceof RuntimeException ? (RuntimeException) e : new RuntimeException(e.getClass().getName() + ": " + e.getMessage(), e);
         }
     }
 

--- a/src/main/java/no/digipost/signature/client/core/internal/ClientExceptionMapper.java
+++ b/src/main/java/no/digipost/signature/client/core/internal/ClientExceptionMapper.java
@@ -17,12 +17,10 @@ package no.digipost.signature.client.core.internal;
 
 import no.digipost.signature.client.core.exceptions.ConfigurationException;
 import no.digipost.signature.client.core.exceptions.SignatureException;
-import no.motif.Exceptions;
 
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
 import javax.ws.rs.ProcessingException;
-
 import java.util.concurrent.Callable;
 
 class ClientExceptionMapper {
@@ -43,12 +41,12 @@ class ClientExceptionMapper {
         } catch (ProcessingException e) {
             throw map(e);
         } catch (Exception e) {
-            throw Exceptions.asRuntimeException(e);
+            throw e instanceof RuntimeException ? (RuntimeException) e : new RuntimeException(e.getClass().getName() + ": " + e.getMessage(), e);
         }
     }
 
 
-    RuntimeException map(ProcessingException e) {
+    private RuntimeException map(ProcessingException e) {
         if (e.getCause() instanceof SSLException) {
             String sslExceptionMessage = e.getCause().getMessage();
             if (sslExceptionMessage != null && sslExceptionMessage.contains("protocol_version")) {

--- a/src/main/java/no/digipost/signature/client/core/internal/JobCustomizations.java
+++ b/src/main/java/no/digipost/signature/client/core/internal/JobCustomizations.java
@@ -35,7 +35,7 @@ public interface JobCustomizations<B extends JobCustomizations<B>> {
      * You may use {@link no.digipost.signature.client.ClientConfiguration.Builder#globalSender(Sender)}
      * to specify a global sender used for all signature jobs.
      */
-    public B withSender(Sender sender);
+    B withSender(Sender sender);
 
 
     /**

--- a/src/main/java/no/digipost/signature/client/core/internal/MarshallableEnum.java
+++ b/src/main/java/no/digipost/signature/client/core/internal/MarshallableEnum.java
@@ -15,22 +15,8 @@
  */
 package no.digipost.signature.client.core.internal;
 
-import no.motif.f.Fn;
-
 public interface MarshallableEnum<XML_ENUM_TYPE> {
 
     XML_ENUM_TYPE getXmlEnumValue();
-
-    final class To {
-        public static <X> Fn<MarshallableEnum<X>, X> xmlValue() {
-            return new Fn<MarshallableEnum<X>, X>() {
-                @Override
-                public X $(MarshallableEnum<X> marshallableEnum) {
-                    return marshallableEnum.getXmlEnumValue();
-                }
-            };
-        }
-        private To() {}
-    }
 
 }

--- a/src/main/java/no/digipost/signature/client/core/internal/http/PostenEnterpriseCertificateStrategy.java
+++ b/src/main/java/no/digipost/signature/client/core/internal/http/PostenEnterpriseCertificateStrategy.java
@@ -36,7 +36,6 @@ public class PostenEnterpriseCertificateStrategy implements TrustStrategy {
     private static final String SERIALNUMBER_POSTEN = "SERIALNUMBER=" + POSTEN_ORGANIZATION_NUMBER;
 
 
-    @Override
     /**
      * Verify that the server certificate is issued to Posten Norge AS.
      *
@@ -49,6 +48,7 @@ public class PostenEnterpriseCertificateStrategy implements TrustStrategy {
      *
      * @see org.apache.http.ssl.SSLContextBuilder.TrustManagerDelegate#checkServerTrusted(X509Certificate[], String)
      */
+    @Override
     public boolean isTrusted(X509Certificate[] chain, String authType) throws CertificateException {
         String subjectDN = chain[0].getSubjectDN().getName();
 

--- a/src/main/java/no/digipost/signature/client/core/internal/security/TrustStoreLoader.java
+++ b/src/main/java/no/digipost/signature/client/core/internal/security/TrustStoreLoader.java
@@ -81,11 +81,11 @@ public class TrustStoreLoader {
 
     private static class ClassPathFileLoader implements ResourceLoader {
 
-        public static final String CLASSPATH_PATH_PREFIX = "classpath:";
+        static final String CLASSPATH_PATH_PREFIX = "classpath:";
 
         private final String certificatePath;
 
-        public ClassPathFileLoader(String certificateFolder) {
+        ClassPathFileLoader(String certificateFolder) {
             this.certificatePath = certificateFolder.substring(CLASSPATH_PATH_PREFIX.length());
         }
 
@@ -102,7 +102,7 @@ public class TrustStoreLoader {
     private static class FileLoader implements ResourceLoader {
         private final File path;
 
-        public FileLoader(String certificateFolder) {
+        FileLoader(String certificateFolder) {
             this.path = new File(certificateFolder);
         }
 

--- a/src/main/java/no/digipost/signature/client/direct/DirectClient.java
+++ b/src/main/java/no/digipost/signature/client/direct/DirectClient.java
@@ -28,9 +28,9 @@ import no.digipost.signature.client.core.Sender;
 import no.digipost.signature.client.core.XAdESReference;
 import no.digipost.signature.client.core.internal.ClientHelper;
 import no.digipost.signature.client.core.internal.http.SignatureHttpClientFactory;
-import no.motif.Singular;
 
 import java.io.InputStream;
+import java.util.Optional;
 
 import static no.digipost.signature.client.direct.DirectJobStatusResponse.NO_UPDATED_STATUS;
 import static no.digipost.signature.client.direct.JaxbEntityMapping.fromJaxb;
@@ -106,7 +106,7 @@ public class DirectClient {
      *         never {@code null}.
      */
     public DirectJobStatusResponse getStatusChange(Sender sender) {
-        XMLDirectSignatureJobStatusResponse statusChange = client.getDirectStatusChange(Singular.optional(sender));
+        XMLDirectSignatureJobStatusResponse statusChange = client.getDirectStatusChange(Optional.ofNullable(sender));
         return statusChange == null ? NO_UPDATED_STATUS : fromJaxb(statusChange);
     }
 

--- a/src/main/java/no/digipost/signature/client/direct/DirectJob.java
+++ b/src/main/java/no/digipost/signature/client/direct/DirectJob.java
@@ -20,16 +20,14 @@ import no.digipost.signature.client.core.IdentifierInSignedDocuments;
 import no.digipost.signature.client.core.Sender;
 import no.digipost.signature.client.core.SignatureJob;
 import no.digipost.signature.client.core.internal.JobCustomizations;
-import no.motif.Singular;
-import no.motif.single.Optional;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import static java.util.Collections.unmodifiableList;
-import static no.motif.Singular.optional;
 
 public class DirectJob implements SignatureJob, WithExitUrls {
 
@@ -39,10 +37,10 @@ public class DirectJob implements SignatureJob, WithExitUrls {
     private String completionUrl;
     private String rejectionUrl;
     private String errorUrl;
-    private Optional<Sender> sender = Singular.none();
-    private Optional<StatusRetrievalMethod> statusRetrievalMethod = Singular.none();
-    private Optional<AuthenticationLevel> requiredAuthentication = Singular.none();
-    private Optional<IdentifierInSignedDocuments> identifierInSignedDocuments = Singular.none();
+    private Optional<Sender> sender = Optional.empty();
+    private Optional<StatusRetrievalMethod> statusRetrievalMethod = Optional.empty();
+    private Optional<AuthenticationLevel> requiredAuthentication = Optional.empty();
+    private Optional<IdentifierInSignedDocuments> identifierInSignedDocuments = Optional.empty();
 
     private DirectJob(List<DirectSigner> signers, DirectDocument document, String completionUrl, String rejectionUrl, String errorUrl) {
         this.signers = unmodifiableList(new ArrayList<>(signers));
@@ -155,24 +153,24 @@ public class DirectJob implements SignatureJob, WithExitUrls {
 
         @Override
         public Builder withSender(Sender sender) {
-            target.sender = Singular.optional(sender);
+            target.sender = Optional.of(sender);
             return this;
         }
 
         @Override
         public Builder requireAuthentication(AuthenticationLevel level) {
-            target.requiredAuthentication = optional(level);
+            target.requiredAuthentication = Optional.of(level);
             return this;
         }
 
         @Override
         public Builder withIdentifierInSignedDocuments(IdentifierInSignedDocuments identifier) {
-            target.identifierInSignedDocuments = optional(identifier);
+            target.identifierInSignedDocuments = Optional.of(identifier);
             return this;
         }
 
         public Builder retrieveStatusBy(StatusRetrievalMethod statusRetrievalMethod) {
-            target.statusRetrievalMethod = optional(statusRetrievalMethod);
+            target.statusRetrievalMethod = Optional.of(statusRetrievalMethod);
             return this;
         }
 

--- a/src/main/java/no/digipost/signature/client/direct/DirectJobStatusResponse.java
+++ b/src/main/java/no/digipost/signature/client/direct/DirectJobStatusResponse.java
@@ -18,13 +18,11 @@ package no.digipost.signature.client.direct;
 import no.digipost.signature.client.core.ConfirmationReference;
 import no.digipost.signature.client.core.PAdESReference;
 import no.digipost.signature.client.core.internal.Confirmable;
-import no.motif.f.Fn0;
 
 import java.util.List;
 
 import static no.digipost.signature.client.direct.DirectJobStatus.NO_CHANGES;
 import static no.digipost.signature.client.direct.Signature.signatureFrom;
-import static no.motif.Iterate.on;
 
 
 public class DirectJobStatusResponse implements Confirmable {
@@ -99,15 +97,10 @@ public class DirectJobStatusResponse implements Confirmable {
      * @see #getSignatures()
      */
     public Signature getSignatureFrom(final String signer) {
-        return on(signatures)
+        return signatures.stream()
                 .filter(signatureFrom(signer))
-                .head()
-                .orElseThrow(new Fn0<IllegalArgumentException>() {
-                    @Override
-                    public IllegalArgumentException $() {
-                        return new IllegalArgumentException("Unable to find signature from this signer");
-                    }
-                });
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Unable to find signature from this signer"));
     }
 
     @Override

--- a/src/main/java/no/digipost/signature/client/direct/DirectSigner.java
+++ b/src/main/java/no/digipost/signature/client/direct/DirectSigner.java
@@ -18,11 +18,10 @@ package no.digipost.signature.client.direct;
 import no.digipost.signature.client.core.OnBehalfOf;
 import no.digipost.signature.client.core.SignatureType;
 import no.digipost.signature.client.core.internal.SignerCustomizations;
-import no.motif.Singular;
-import no.motif.single.Optional;
+
+import java.util.Optional;
 
 import static no.digipost.signature.client.core.internal.PersonalIdentificationNumbers.mask;
-import static no.motif.Singular.optional;
 
 public class DirectSigner {
 
@@ -38,8 +37,8 @@ public class DirectSigner {
 
         private String personalIdentificationNumber;
         private String customIdentifier;
-        private Optional<SignatureType> signatureType = Singular.none();
-        private Optional<OnBehalfOf> onBehalfOf = Singular.none();
+        private Optional<SignatureType> signatureType = Optional.empty();
+        private Optional<OnBehalfOf> onBehalfOf = Optional.empty();
 
         private Builder(String personalIdentificationNumber, String customIdentifier) {
             this.personalIdentificationNumber = personalIdentificationNumber;
@@ -48,13 +47,13 @@ public class DirectSigner {
 
         @Override
         public Builder withSignatureType(SignatureType type) {
-            this.signatureType = optional(type);
+            this.signatureType = Optional.of(type);
             return this;
         }
 
         @Override
         public Builder onBehalfOf(OnBehalfOf onBehalfOf) {
-            this.onBehalfOf = optional(onBehalfOf);
+            this.onBehalfOf = Optional.of(onBehalfOf);
             return this;
         }
 

--- a/src/main/java/no/digipost/signature/client/direct/JaxbEntityMapping.java
+++ b/src/main/java/no/digipost/signature/client/direct/JaxbEntityMapping.java
@@ -65,7 +65,7 @@ final class JaxbEntityMapping {
             signatures.add(new Signature(
                     signerStatus.getSigner(),
                     SignerStatus.fromXmlType(signerStatus.getValue()),
-                    signerStatus.getSince(),
+                    signerStatus.getSince().toInstant(),
                     XAdESReference.of(xAdESUrl)
             ));
         }

--- a/src/main/java/no/digipost/signature/client/direct/JaxbEntityMapping.java
+++ b/src/main/java/no/digipost/signature/client/direct/JaxbEntityMapping.java
@@ -21,19 +21,14 @@ import no.digipost.signature.api.xml.XMLDirectSignatureJobStatusResponse;
 import no.digipost.signature.api.xml.XMLExitUrls;
 import no.digipost.signature.api.xml.XMLSignerSpecificUrl;
 import no.digipost.signature.api.xml.XMLSignerStatus;
-import no.digipost.signature.api.xml.XMLStatusRetrievalMethod;
 import no.digipost.signature.client.core.ConfirmationReference;
 import no.digipost.signature.client.core.PAdESReference;
 import no.digipost.signature.client.core.XAdESReference;
-import no.digipost.signature.client.core.internal.MarshallableEnum;
 import no.digipost.signature.client.direct.RedirectUrls.RedirectUrl;
-import no.motif.f.Fn;
-import no.motif.f.Predicate;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import static no.motif.Iterate.on;
+import java.util.function.Predicate;
 
 final class JaxbEntityMapping {
 
@@ -45,7 +40,7 @@ final class JaxbEntityMapping {
                         .withRejectionUrl(signatureJob.getRejectionUrl())
                         .withErrorUrl(signatureJob.getErrorUrl())
                 )
-                .withStatusRetrievalMethod(signatureJob.getStatusRetrievalMethod().map(MarshallableEnum.To.<XMLStatusRetrievalMethod>xmlValue()).orNull());
+                .withStatusRetrievalMethod(signatureJob.getStatusRetrievalMethod().map(StatusRetrievalMethod::getXmlEnumValue).orElse(null));
     }
 
     static DirectJobResponse fromJaxb(XMLDirectSignatureJobResponse xmlSignatureJobResponse) {
@@ -60,11 +55,11 @@ final class JaxbEntityMapping {
     static DirectJobStatusResponse fromJaxb(XMLDirectSignatureJobStatusResponse statusResponse) {
         List<Signature> signatures = new ArrayList<>();
         for (XMLSignerStatus signerStatus : statusResponse.getStatuses()) {
-            String xAdESUrl = on(statusResponse.getXadesUrls())
+            String xAdESUrl = statusResponse.getXadesUrls().stream()
                     .filter(forSigner(signerStatus.getSigner()))
-                    .head()
-                    .map(getUrl())
-                    .orNull();
+                    .findFirst()
+                    .map(XMLSignerSpecificUrl::getValue)
+                    .orElse(null);
 
             signatures.add(new Signature(
                     signerStatus.getSigner(),
@@ -82,15 +77,7 @@ final class JaxbEntityMapping {
                 PAdESReference.of(statusResponse.getPadesUrl()));
     }
 
-    private static Fn<XMLSignerSpecificUrl, String> getUrl() {
-        return new Fn<XMLSignerSpecificUrl, String>() {
-            @Override public String $(XMLSignerSpecificUrl url) { return url.getValue(); }
-        };
-    }
-
     private static Predicate<XMLSignerSpecificUrl> forSigner(final String signer) {
-        return new Predicate<XMLSignerSpecificUrl>() {
-            @Override public boolean $(XMLSignerSpecificUrl url) { return url.getSigner().equals(signer); }
-        };
+        return url -> url.getSigner().equals(signer);
     }
 }

--- a/src/main/java/no/digipost/signature/client/direct/JaxbEntityMapping.java
+++ b/src/main/java/no/digipost/signature/client/direct/JaxbEntityMapping.java
@@ -30,6 +30,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Predicate;
 
+import static java.util.stream.Collectors.toList;
+
 final class JaxbEntityMapping {
 
     static XMLDirectSignatureJobRequest toJaxb(DirectJob signatureJob) {
@@ -44,10 +46,9 @@ final class JaxbEntityMapping {
     }
 
     static DirectJobResponse fromJaxb(XMLDirectSignatureJobResponse xmlSignatureJobResponse) {
-        List<RedirectUrl> redirectUrls = new ArrayList<>();
-        for (XMLSignerSpecificUrl redirectUrl : xmlSignatureJobResponse.getRedirectUrls()) {
-            redirectUrls.add(new RedirectUrl(redirectUrl.getSigner(), redirectUrl.getValue()));
-        }
+        List<RedirectUrl> redirectUrls = xmlSignatureJobResponse.getRedirectUrls().stream()
+                .map(RedirectUrl::fromJaxb)
+                .collect(toList());
 
         return new DirectJobResponse(xmlSignatureJobResponse.getSignatureJobId(), redirectUrls, xmlSignatureJobResponse.getStatusUrl());
     }

--- a/src/main/java/no/digipost/signature/client/direct/RedirectUrls.java
+++ b/src/main/java/no/digipost/signature/client/direct/RedirectUrls.java
@@ -15,6 +15,8 @@
  */
 package no.digipost.signature.client.direct;
 
+import no.digipost.signature.api.xml.XMLSignerSpecificUrl;
+
 import java.util.List;
 
 public class RedirectUrls {
@@ -56,9 +58,13 @@ public class RedirectUrls {
 
         private final String url;
 
-        public RedirectUrl(String signer, String url) {
+        private RedirectUrl(String signer, String url) {
             this.signer = signer;
             this.url = url;
+        }
+
+        static RedirectUrl fromJaxb(XMLSignerSpecificUrl xmlSignerSpecificUrl) {
+            return new RedirectUrl(xmlSignerSpecificUrl.getSigner(), xmlSignerSpecificUrl.getValue());
         }
 
         public String getSigner() {

--- a/src/main/java/no/digipost/signature/client/direct/Signature.java
+++ b/src/main/java/no/digipost/signature/client/direct/Signature.java
@@ -16,9 +16,9 @@
 package no.digipost.signature.client.direct;
 
 import no.digipost.signature.client.core.XAdESReference;
-import no.motif.f.Predicate;
 
 import java.util.Date;
+import java.util.function.Predicate;
 
 import static no.digipost.signature.client.core.internal.PersonalIdentificationNumbers.mask;
 
@@ -74,12 +74,7 @@ public class Signature {
     }
 
     static Predicate<Signature> signatureFrom(final String signer) {
-        return new Predicate<Signature>() {
-            @Override
-            public boolean $(Signature signature) {
-                return signature.isFrom(signer);
-            }
-        };
+        return signature -> signature.isFrom(signer);
     }
 
 

--- a/src/main/java/no/digipost/signature/client/direct/Signature.java
+++ b/src/main/java/no/digipost/signature/client/direct/Signature.java
@@ -17,7 +17,7 @@ package no.digipost.signature.client.direct;
 
 import no.digipost.signature.client.core.XAdESReference;
 
-import java.util.Date;
+import java.time.Instant;
 import java.util.function.Predicate;
 
 import static no.digipost.signature.client.core.internal.PersonalIdentificationNumbers.mask;
@@ -28,11 +28,11 @@ public class Signature {
     private final String signer;
 
     private final SignerStatus status;
-    private final Date statusDateTime;
+    private final Instant statusDateTime;
 
     private final XAdESReference xAdESReference;
 
-    public Signature(String signer, SignerStatus status, Date statusDateTime, XAdESReference xAdESReference) {
+    public Signature(String signer, SignerStatus status, Instant statusDateTime, XAdESReference xAdESReference) {
         this.signer = signer;
         this.status = status;
         this.statusDateTime = statusDateTime;
@@ -59,7 +59,7 @@ public class Signature {
      * @return Point in time when the action (document was signed, signature job expired, etc.) leading to the
      * current {@link Signature#status} happened.
      */
-    public Date getStatusDateTime() {
+    public Instant getStatusDateTime() {
         return statusDateTime;
     }
 

--- a/src/main/java/no/digipost/signature/client/direct/SignerStatus.java
+++ b/src/main/java/no/digipost/signature/client/direct/SignerStatus.java
@@ -64,7 +64,7 @@ public class SignerStatus {
         this.identifier = identifier;
     }
 
-    public static SignerStatus fromXmlType(String xmlSignerStatus) {
+    static SignerStatus fromXmlType(String xmlSignerStatus) {
         for (SignerStatus status : KNOWN_STATUSES) {
             if (status.is(xmlSignerStatus)) {
                 return status;

--- a/src/main/java/no/digipost/signature/client/portal/JaxbEntityMapping.java
+++ b/src/main/java/no/digipost/signature/client/portal/JaxbEntityMapping.java
@@ -45,7 +45,7 @@ final class JaxbEntityMapping {
                     xmlSignature.getPersonalIdentificationNumber(),
                     xmlSignature.getIdentifier(),
                     SignatureStatus.fromXmlType(xmlSignature.getStatus()),
-                    xmlSignature.getStatus().getSince(),
+                    xmlSignature.getStatus().getSince().toInstant(),
                     XAdESReference.of(xmlSignature.getXadesUrl())
             ));
         }

--- a/src/main/java/no/digipost/signature/client/portal/NotificationsUsingLookup.java
+++ b/src/main/java/no/digipost/signature/client/portal/NotificationsUsingLookup.java
@@ -23,7 +23,7 @@ public enum NotificationsUsingLookup {
     public final boolean shouldSendEmail;
     public final boolean shouldSendSms;
 
-    private NotificationsUsingLookup(boolean sendEmail, boolean sendSms) {
+    NotificationsUsingLookup(boolean sendEmail, boolean sendSms) {
         this.shouldSendEmail = sendEmail;
         this.shouldSendSms = sendSms;
     }

--- a/src/main/java/no/digipost/signature/client/portal/PortalClient.java
+++ b/src/main/java/no/digipost/signature/client/portal/PortalClient.java
@@ -44,7 +44,7 @@ public class PortalClient {
 
     public PortalClient(ClientConfiguration config) {
         this.client = new ClientHelper(SignatureHttpClientFactory.create(config), config.getGlobalSender());
-        this.aSiCECreator = new CreateASiCE<>(new CreatePortalManifest(), config);
+        this.aSiCECreator = new CreateASiCE<>(new CreatePortalManifest(config.getClock()), config);
     }
 
 

--- a/src/main/java/no/digipost/signature/client/portal/PortalClient.java
+++ b/src/main/java/no/digipost/signature/client/portal/PortalClient.java
@@ -29,9 +29,9 @@ import no.digipost.signature.client.core.XAdESReference;
 import no.digipost.signature.client.core.internal.Cancellable;
 import no.digipost.signature.client.core.internal.ClientHelper;
 import no.digipost.signature.client.core.internal.http.SignatureHttpClientFactory;
-import no.motif.Singular;
 
 import java.io.InputStream;
+import java.util.Optional;
 
 import static no.digipost.signature.client.portal.JaxbEntityMapping.fromJaxb;
 import static no.digipost.signature.client.portal.JaxbEntityMapping.toJaxb;
@@ -87,7 +87,7 @@ public class PortalClient {
      */
 
     public PortalJobStatusChanged getStatusChange(Sender sender) {
-        XMLPortalSignatureJobStatusChangeResponse statusChange = client.getPortalStatusChange(Singular.optional(sender));
+        XMLPortalSignatureJobStatusChangeResponse statusChange = client.getPortalStatusChange(Optional.ofNullable(sender));
         return statusChange == null ? NO_UPDATED_STATUS : JaxbEntityMapping.fromJaxb(statusChange);
     }
 

--- a/src/main/java/no/digipost/signature/client/portal/PortalJob.java
+++ b/src/main/java/no/digipost/signature/client/portal/PortalJob.java
@@ -21,9 +21,9 @@ import no.digipost.signature.client.core.Sender;
 import no.digipost.signature.client.core.SignatureJob;
 import no.digipost.signature.client.core.internal.JobCustomizations;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -37,7 +37,7 @@ public class PortalJob implements SignatureJob {
     private final List<PortalSigner> signers;
     private final PortalDocument document;
     private String reference;
-    private Date activationTime;
+    private Optional<Instant> activationTime = Optional.empty();
     private Long availableSeconds;
     private Optional<Sender> sender = Optional.empty();
     private Optional<AuthenticationLevel> requiredAuthentication = Optional.empty();
@@ -77,7 +77,7 @@ public class PortalJob implements SignatureJob {
         return signers;
     }
 
-    public Date getActivationTime() {
+    public Optional<Instant> getActivationTime() {
         return activationTime;
     }
 
@@ -132,8 +132,8 @@ public class PortalJob implements SignatureJob {
             return this;
         }
 
-        public Builder withActivationTime(Date activationTime) {
-            target.activationTime = activationTime;
+        public Builder withActivationTime(Instant activationTime) {
+            target.activationTime = Optional.of(activationTime);
             return this;
         }
 

--- a/src/main/java/no/digipost/signature/client/portal/PortalJob.java
+++ b/src/main/java/no/digipost/signature/client/portal/PortalJob.java
@@ -20,18 +20,16 @@ import no.digipost.signature.client.core.IdentifierInSignedDocuments;
 import no.digipost.signature.client.core.Sender;
 import no.digipost.signature.client.core.SignatureJob;
 import no.digipost.signature.client.core.internal.JobCustomizations;
-import no.motif.Singular;
-import no.motif.single.Optional;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import static java.util.Collections.unmodifiableList;
-import static no.motif.Singular.optional;
 
 
 public class PortalJob implements SignatureJob {
@@ -41,9 +39,9 @@ public class PortalJob implements SignatureJob {
     private String reference;
     private Date activationTime;
     private Long availableSeconds;
-    private Optional<Sender> sender = Singular.none();
-    private Optional<AuthenticationLevel> requiredAuthentication = Singular.none();
-    private Optional<IdentifierInSignedDocuments> identifierInSignedDocuments = Singular.none();
+    private Optional<Sender> sender = Optional.empty();
+    private Optional<AuthenticationLevel> requiredAuthentication = Optional.empty();
+    private Optional<IdentifierInSignedDocuments> identifierInSignedDocuments = Optional.empty();
 
     private PortalJob(List<PortalSigner> signers, PortalDocument document) {
         this.signers = unmodifiableList(new ArrayList<>(signers));
@@ -118,19 +116,19 @@ public class PortalJob implements SignatureJob {
 
         @Override
         public Builder withSender(Sender sender) {
-            target.sender = optional(sender);
+            target.sender = Optional.of(sender);
             return this;
         }
 
         @Override
         public Builder requireAuthentication(AuthenticationLevel minimumLevel) {
-            target.requiredAuthentication = optional(minimumLevel);
+            target.requiredAuthentication = Optional.of(minimumLevel);
             return this;
         }
 
         @Override
         public Builder withIdentifierInSignedDocuments(IdentifierInSignedDocuments identifier) {
-            target.identifierInSignedDocuments = optional(identifier);
+            target.identifierInSignedDocuments = Optional.of(identifier);
             return this;
         }
 

--- a/src/main/java/no/digipost/signature/client/portal/PortalJobStatusChanged.java
+++ b/src/main/java/no/digipost/signature/client/portal/PortalJobStatusChanged.java
@@ -19,13 +19,11 @@ import no.digipost.signature.client.core.ConfirmationReference;
 import no.digipost.signature.client.core.PAdESReference;
 import no.digipost.signature.client.core.internal.Cancellable;
 import no.digipost.signature.client.core.internal.Confirmable;
-import no.motif.f.Fn0;
 
 import java.util.List;
 
 import static no.digipost.signature.client.portal.PortalJobStatus.NO_CHANGES;
 import static no.digipost.signature.client.portal.Signature.signatureFrom;
-import static no.motif.Iterate.on;
 
 /**
  * Indicates a job which has got a new {@link PortalJobStatus status}
@@ -114,15 +112,10 @@ public class PortalJobStatusChanged implements Confirmable, Cancellable {
      * @throws IllegalArgumentException if the job response doesn't contain a signature from this signer
      */
     public Signature getSignatureFrom(SignerIdentifier signer) {
-        return on(signatures)
+        return signatures.stream()
                 .filter(signatureFrom(signer))
-                .head()
-                .orElseThrow(new Fn0<IllegalArgumentException>() {
-                    @Override
-                    public IllegalArgumentException $() {
-                        return new IllegalArgumentException("Unable to find signature from this signer");
-                    }
-                });
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Unable to find signature from this signer"));
     }
 
     @Override

--- a/src/main/java/no/digipost/signature/client/portal/PortalSigner.java
+++ b/src/main/java/no/digipost/signature/client/portal/PortalSigner.java
@@ -19,9 +19,8 @@ import no.digipost.signature.client.core.OnBehalfOf;
 import no.digipost.signature.client.core.SignatureType;
 import no.digipost.signature.client.core.internal.IdentifierType;
 import no.digipost.signature.client.core.internal.SignerCustomizations;
-import no.motif.Singular;
-import no.motif.single.A;
-import no.motif.single.Optional;
+
+import java.util.Optional;
 
 import static no.digipost.signature.client.core.OnBehalfOf.OTHER;
 import static no.digipost.signature.client.core.internal.IdentifierType.EMAIL;
@@ -29,7 +28,6 @@ import static no.digipost.signature.client.core.internal.IdentifierType.EMAIL_AN
 import static no.digipost.signature.client.core.internal.IdentifierType.MOBILE_NUMBER;
 import static no.digipost.signature.client.core.internal.IdentifierType.PERSONAL_IDENTIFICATION_NUMBER;
 import static no.digipost.signature.client.core.internal.PersonalIdentificationNumbers.mask;
-import static no.motif.Singular.optional;
 
 public class PortalSigner {
 
@@ -40,17 +38,17 @@ public class PortalSigner {
     private NotificationsUsingLookup notificationsUsingLookup;
 
     private int order = 0;
-    private Optional<SignatureType> signatureType = Singular.none();
-    private Optional<OnBehalfOf> onBehalfOf = Singular.none();
+    private Optional<SignatureType> signatureType = Optional.empty();
+    private Optional<OnBehalfOf> onBehalfOf = Optional.empty();
 
     private PortalSigner(IdentifierType identifierType, Notifications notifications) {
-        this.identifier = Singular.none();
+        this.identifier = Optional.empty();
         this.identifierType = identifierType;
         this.notifications = notifications;
     }
 
     private PortalSigner(String personalIdentificationNumber, Notifications notifications, NotificationsUsingLookup notificationsUsingLookup) {
-        this.identifier = Singular.optional(personalIdentificationNumber);
+        this.identifier = Optional.of(personalIdentificationNumber);
         this.identifierType = PERSONAL_IDENTIFICATION_NUMBER;
         this.notifications = notifications;
         this.notificationsUsingLookup = notificationsUsingLookup;
@@ -150,18 +148,18 @@ public class PortalSigner {
 
         @Override
         public Builder withSignatureType(SignatureType type) {
-            target.signatureType = optional(type);
+            target.signatureType = Optional.of(type);
             return this;
         }
 
         @Override
         public Builder onBehalfOf(OnBehalfOf onBehalfOf) {
-            target.onBehalfOf = optional(onBehalfOf);
+            target.onBehalfOf = Optional.of(onBehalfOf);
             return this;
         }
 
         public PortalSigner build() {
-            if (target.onBehalfOf.isSome() && target.onBehalfOf.get() == OTHER && target.notificationsUsingLookup != null) {
+            if (target.onBehalfOf.isPresent() && target.onBehalfOf.get() == OTHER && target.notificationsUsingLookup != null) {
                 throw new IllegalStateException("Can't look up contact information for notifications when signing on behalf of a third party");
             }
             if (built) throw new IllegalStateException("Can't build twice");

--- a/src/main/java/no/digipost/signature/client/portal/PortalSigner.java
+++ b/src/main/java/no/digipost/signature/client/portal/PortalSigner.java
@@ -54,22 +54,6 @@ public class PortalSigner {
         this.notificationsUsingLookup = notificationsUsingLookup;
     }
 
-    /**
-     * @deprecated See {@link #identifiedByPersonalIdentificationNumber(String, Notifications)}
-     */
-    @Deprecated
-    public static Builder builder(String personalIdentificationNumber, Notifications notifications) {
-        return new Builder(personalIdentificationNumber, notifications, null);
-    }
-
-    /**
-     * @deprecated See {@link #identifiedByPersonalIdentificationNumber(String, NotificationsUsingLookup)}
-     */
-    @Deprecated
-    public static Builder builder(String personalIdentificationNumber, NotificationsUsingLookup notificationsUsingLookup) {
-        return new Builder(personalIdentificationNumber, null, notificationsUsingLookup);
-    }
-
     public static Builder identifiedByPersonalIdentificationNumber(String personalIdentificationNumber, Notifications notifications) {
         return new Builder(personalIdentificationNumber, notifications, null);
     }

--- a/src/main/java/no/digipost/signature/client/portal/Signature.java
+++ b/src/main/java/no/digipost/signature/client/portal/Signature.java
@@ -18,9 +18,9 @@ package no.digipost.signature.client.portal;
 import no.digipost.signature.api.xml.XMLNotifications;
 import no.digipost.signature.client.core.XAdESReference;
 import no.digipost.signature.client.core.exceptions.SignatureException;
-import no.motif.f.Predicate;
 
 import java.util.Date;
+import java.util.function.Predicate;
 
 import static no.digipost.signature.client.core.internal.PersonalIdentificationNumbers.mask;
 
@@ -61,12 +61,7 @@ public class Signature {
     }
 
     static Predicate<Signature> signatureFrom(final SignerIdentifier signer) {
-        return new Predicate<Signature>() {
-            @Override
-            public boolean $(Signature signature) {
-                return signature.signer.isSameAs(signer);
-            }
-        };
+        return signature -> signature.signer.isSameAs(signer);
     }
 
     /**

--- a/src/main/java/no/digipost/signature/client/portal/Signature.java
+++ b/src/main/java/no/digipost/signature/client/portal/Signature.java
@@ -19,7 +19,7 @@ import no.digipost.signature.api.xml.XMLNotifications;
 import no.digipost.signature.client.core.XAdESReference;
 import no.digipost.signature.client.core.exceptions.SignatureException;
 
-import java.util.Date;
+import java.time.Instant;
 import java.util.function.Predicate;
 
 import static no.digipost.signature.client.core.internal.PersonalIdentificationNumbers.mask;
@@ -28,11 +28,11 @@ public class Signature {
 
     private final Signer signer;
     private final SignatureStatus status;
-    private final Date statusDateTime;
+    private final Instant statusDateTime;
 
     private final XAdESReference xAdESReference;
 
-    public Signature(String personalIdentificationNumber, XMLNotifications identifier, SignatureStatus status, Date statusDateTime, XAdESReference xAdESReference) {
+    public Signature(String personalIdentificationNumber, XMLNotifications identifier, SignatureStatus status, Instant statusDateTime, XAdESReference xAdESReference) {
         this.signer = new Signer(personalIdentificationNumber, identifier);
         this.status = status;
         this.xAdESReference = xAdESReference;
@@ -68,7 +68,7 @@ public class Signature {
      * @return Point in time when the action (document was signed, signature job expired, etc.) leading to the
      * current {@link Signature#status} happened.
      */
-    public Date getStatusDateTime() {
+    public Instant getStatusDateTime() {
         return statusDateTime;
     }
 

--- a/src/main/java/no/digipost/signature/client/portal/SignatureStatus.java
+++ b/src/main/java/no/digipost/signature/client/portal/SignatureStatus.java
@@ -96,7 +96,7 @@ public final class SignatureStatus {
         this.identifier = identifier;
     }
 
-    public static SignatureStatus fromXmlType(XMLSignatureStatus xmlSignatureStatus) {
+    static SignatureStatus fromXmlType(XMLSignatureStatus xmlSignatureStatus) {
         String value = xmlSignatureStatus.getValue();
         for (SignatureStatus status : KNOWN_STATUSES) {
             if (status.is(value)) {

--- a/src/test/java/no/digipost/signature/client/asice/CreateASiCETest.java
+++ b/src/test/java/no/digipost/signature/client/asice/CreateASiCETest.java
@@ -51,7 +51,6 @@ import static java.util.concurrent.TimeUnit.DAYS;
 import static no.digipost.signature.client.TestKonfigurasjon.CLIENT_KEYSTORE;
 import static no.digipost.signature.client.asice.DumpDocumentBundleToDisk.referenceFilenamePart;
 import static no.digipost.signature.client.direct.ExitUrls.singleExitUrl;
-import static no.motif.Iterate.on;
 import static org.hamcrest.Matchers.hasItem;
 import static org.junit.Assert.assertThat;
 
@@ -107,8 +106,8 @@ public class CreateASiCETest {
         aSiCECreator.createASiCE(job);
 
         Path asiceFile;
-        try (DirectoryStream<Path> dumpedFileStream = newDirectoryStream(dumpFolder, "*-" + referenceFilenamePart.$(job.getReference()) + "*.zip")) {
-            asiceFile = on(dumpedFileStream).eval().head().get();
+        try (DirectoryStream<Path> dumpedFileStream = newDirectoryStream(dumpFolder, "*-" + referenceFilenamePart.apply(job.getReference()) + "*.zip")) {
+            asiceFile = dumpedFileStream.iterator().next();
         }
 
         List<String> fileNames = new ArrayList<>();

--- a/src/test/java/no/digipost/signature/client/asice/manifest/CreatePortalManifestTest.java
+++ b/src/test/java/no/digipost/signature/client/asice/manifest/CreatePortalManifestTest.java
@@ -24,17 +24,19 @@ import no.digipost.signature.client.portal.PortalJob;
 import no.digipost.signature.client.portal.PortalSigner;
 import org.junit.Test;
 
+import java.time.Clock;
 import java.util.Collections;
-import java.util.Date;
 
 import static java.util.concurrent.TimeUnit.DAYS;
 import static org.junit.Assert.fail;
 
 public class CreatePortalManifestTest {
 
+    private final Clock clock = Clock.systemDefaultZone();
+
     @Test
     public void accept_valid_manifest() {
-        CreatePortalManifest createManifest = new CreatePortalManifest();
+        CreatePortalManifest createManifest = new CreatePortalManifest(clock);
 
         PortalDocument document = PortalDocument.builder("Title", "file.txt", "hello".getBytes())
                 .message("Message")
@@ -42,7 +44,7 @@ public class CreatePortalManifestTest {
                 .build();
 
         PortalJob job = PortalJob.builder(document, Collections.singletonList(PortalSigner.identifiedByPersonalIdentificationNumber("12345678910", NotificationsUsingLookup.EMAIL_ONLY).build()))
-                .withActivationTime(new Date())
+                .withActivationTime(clock.instant())
                 .availableFor(30, DAYS)
                 .withIdentifierInSignedDocuments(IdentifierInSignedDocuments.PERSONAL_IDENTIFICATION_NUMBER_AND_NAME)
                 .build();

--- a/src/test/java/no/digipost/signature/client/asice/signature/CreateSignatureTest.java
+++ b/src/test/java/no/digipost/signature/client/asice/signature/CreateSignatureTest.java
@@ -30,6 +30,7 @@ import org.springframework.oxm.jaxb.Jaxb2Marshaller;
 import javax.xml.transform.stream.StreamSource;
 import java.io.ByteArrayInputStream;
 import java.math.BigInteger;
+import java.time.Clock;
 import java.util.List;
 
 import static java.util.Arrays.asList;
@@ -62,7 +63,7 @@ public class CreateSignatureTest {
                 file("manifest.xml", "manifest-innhold".getBytes(), "application/xml")
         );
 
-        createSignature = new CreateSignature();
+        createSignature = new CreateSignature(Clock.systemDefaultZone());
     }
 
     @Test

--- a/src/test/java/no/digipost/signature/client/core/internal/http/ResponseStatusTest.java
+++ b/src/test/java/no/digipost/signature/client/core/internal/http/ResponseStatusTest.java
@@ -27,7 +27,6 @@ import org.junit.contrib.theories.Theory;
 import org.junit.runner.RunWith;
 
 import javax.ws.rs.core.Response.Status;
-import javax.ws.rs.core.Response.StatusType;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -38,12 +37,12 @@ public class ResponseStatusTest {
 
     @Test
     public void resolveStandardHttpStatus() {
-        assertThat(ResponseStatus.resolve(200), is((StatusType) Status.OK));
+        assertThat(ResponseStatus.resolve(200), is(Status.OK));
     }
 
     @Test
     public void resolveCustomHttpStatus() {
-        assertThat(ResponseStatus.resolve(422), is((StatusType) Custom.UNPROCESSABLE_ENTITY));
+        assertThat(ResponseStatus.resolve(422), is(Custom.UNPROCESSABLE_ENTITY));
     }
 
     @Test

--- a/src/test/java/no/digipost/signature/client/portal/PortalSignerTest.java
+++ b/src/test/java/no/digipost/signature/client/portal/PortalSignerTest.java
@@ -15,8 +15,9 @@
  */
 package no.digipost.signature.client.portal;
 
-import no.motif.Singular;
 import org.junit.Test;
+
+import java.util.Optional;
 
 import static no.digipost.signature.client.portal.PortalSigner.identifiedByEmail;
 import static no.digipost.signature.client.portal.PortalSigner.identifiedByEmailAndMobileNumber;
@@ -45,7 +46,7 @@ public class PortalSignerTest {
     public void get_email_custom_identifier() {
         PortalSigner portalSigner = identifiedByEmail("email@example.com").build();
 
-        assertThat(portalSigner.getIdentifier(), is(Singular.<String>none()));
+        assertThat(portalSigner.getIdentifier(), is(Optional.<String>empty()));
         assertThat(portalSigner.getNotifications().getEmailAddress(), is("email@example.com"));
         assertTrue(portalSigner.getNotifications().shouldSendEmail());
         assertFalse(portalSigner.isIdentifiedByPersonalIdentificationNumber());
@@ -55,7 +56,7 @@ public class PortalSignerTest {
     public void get_mobile_number_custom_identifier() {
         PortalSigner portalSigner = identifiedByMobileNumber("12345678").build();
 
-        assertThat(portalSigner.getIdentifier(), is(Singular.<String>none()));
+        assertThat(portalSigner.getIdentifier(), is(Optional.<String>empty()));
         assertThat(portalSigner.getNotifications().getMobileNumber(), is("12345678"));
         assertTrue(portalSigner.getNotifications().shouldSendSms());
         assertFalse(portalSigner.isIdentifiedByPersonalIdentificationNumber());
@@ -65,7 +66,7 @@ public class PortalSignerTest {
     public void get_email_and_mobile_number_custom_identifier() {
         PortalSigner portalSigner = identifiedByEmailAndMobileNumber("email@example.com", "12345678").build();
 
-        assertThat(portalSigner.getIdentifier(), is(Singular.<String>none()));
+        assertThat(portalSigner.getIdentifier(), is(Optional.<String>empty()));
 
         assertThat(portalSigner.getNotifications().getEmailAddress(), is("email@example.com"));
         assertTrue(portalSigner.getNotifications().shouldSendEmail());


### PR DESCRIPTION
Java 8-ifyer kodebasen litt. Erstattet motif med ekvivalenter fra JDKen og tatt i bruk lambdas, `Stream`s o.l. fra JDKen der det er hensiktsmessig.

**Gjenstående:**

- [x] Fjerne et par `@Deprecated` metoder
- [x] `java.util.Date` => `java.time.Instant`
- [x] Kopiere over dokumentasjon til `v3.x`
- [ ] Release som versjon 3.0

Commitene skal være strukturert slik at det går an å gå igjennom en og en i stedet for å se på hele diffen på en gang.

**⚠️ Avhenger av release `2.0` av [API-spesifikasjonen](https://github.com/digipost/signature-api-specification/pull/69)**