### PR TITLE
Inkluderer oppdragets referanse i alle responser knytta til et oppdrag

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <signature.api.version>2.2</signature.api.version>
+        <signature.api.version>2.3</signature.api.version>
         <slf4j.version>1.7.25</slf4j.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <name>Posten signering - Java API Client Library</name>
     <groupId>no.digipost.signature</groupId>
     <artifactId>signature-api-client-java</artifactId>
-    <version>4.2-SNAPSHOT</version>
+    <version>4.2</version>
 
     <parent>
         <groupId>no.digipost</groupId>
@@ -446,7 +446,7 @@
         <connection>scm:git:git@github.com:digipost/signature-api-client-java.git</connection>
         <developerConnection>scm:git:git@github.com:digipost/signature-api-client-java.git</developerConnection>
         <url>https://github.com/digipost/signature-api-client-java/</url>
-        <tag>HEAD</tag>
+        <tag>4.2</tag>
     </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <name>Posten signering - Java API Client Library</name>
     <groupId>no.digipost.signature</groupId>
     <artifactId>signature-api-client-java</artifactId>
-    <version>4.2</version>
+    <version>4.3-SNAPSHOT</version>
 
     <parent>
         <groupId>no.digipost</groupId>
@@ -446,7 +446,7 @@
         <connection>scm:git:git@github.com:digipost/signature-api-client-java.git</connection>
         <developerConnection>scm:git:git@github.com:digipost/signature-api-client-java.git</developerConnection>
         <url>https://github.com/digipost/signature-api-client-java/</url>
-        <tag>4.2</tag>
+        <tag>HEAD</tag>
     </scm>
 
 </project>

--- a/src/main/java/no/digipost/signature/client/direct/DirectJobResponse.java
+++ b/src/main/java/no/digipost/signature/client/direct/DirectJobResponse.java
@@ -21,11 +21,13 @@ import java.util.List;
 
 public class DirectJobResponse {
     private final long signatureJobId;
+    private final String reference;
     private final RedirectUrls redirectUrls;
     private final String statusUrl;
 
-    public DirectJobResponse(long signatureJobId, List<RedirectUrl> redirectUrls, String statusUrl) {
+    public DirectJobResponse(long signatureJobId, String reference, List<RedirectUrl> redirectUrls, String statusUrl) {
         this.signatureJobId = signatureJobId;
+        this.reference = reference;
         this.redirectUrls = new RedirectUrls(redirectUrls);
         this.statusUrl = statusUrl;
     }
@@ -34,7 +36,15 @@ public class DirectJobResponse {
         return signatureJobId;
     }
 
-	/**
+    /**
+     * @return the signature job's custom reference as specified upon
+     * {@link DirectJob.Builder#withReference(String) creation}. May be {@code null}.
+     */
+    public String getReference() {
+        return reference;
+    }
+
+    /**
      * Gets the only redirect URL for this job.
      * Convenience method for retrieving the redirect URL for jobs with exactly one signer.
      * @throws IllegalStateException if there are multiple redirect URLs

--- a/src/main/java/no/digipost/signature/client/direct/DirectJobStatusResponse.java
+++ b/src/main/java/no/digipost/signature/client/direct/DirectJobStatusResponse.java
@@ -16,9 +16,9 @@
 package no.digipost.signature.client.direct;
 
 import no.digipost.signature.client.core.ConfirmationReference;
+import no.digipost.signature.client.core.DeleteDocumentsUrl;
 import no.digipost.signature.client.core.PAdESReference;
 import no.digipost.signature.client.core.internal.Confirmable;
-import no.digipost.signature.client.core.DeleteDocumentsUrl;
 
 import java.time.Instant;
 import java.util.List;
@@ -34,7 +34,7 @@ public class DirectJobStatusResponse implements Confirmable {
      * {@link DirectJobStatusResponse}. Its status is {@link DirectJobStatus#NO_CHANGES NO_CHANGES}.
      */
     static DirectJobStatusResponse noUpdatedStatus(Instant nextPermittedPollTime) {
-        return new DirectJobStatusResponse(null, NO_CHANGES, null, null, null, null, nextPermittedPollTime) {
+        return new DirectJobStatusResponse(null, null, NO_CHANGES, null, null, null, null, nextPermittedPollTime) {
             @Override public long getSignatureJobId() {
                 throw new IllegalStateException(
                         "There were " + this + ", and querying the job ID is a programming error. " +
@@ -50,6 +50,7 @@ public class DirectJobStatusResponse implements Confirmable {
     }
 
     private final Long signatureJobId;
+    private final String reference;
     private final DirectJobStatus status;
     private final ConfirmationReference confirmationReference;
     private final DeleteDocumentsUrl deleteDocumentsUrl;
@@ -57,8 +58,9 @@ public class DirectJobStatusResponse implements Confirmable {
     private final PAdESReference pAdESReference;
     private final Instant nextPermittedPollTime;
 
-    public DirectJobStatusResponse(Long signatureJobId, DirectJobStatus signatureJobStatus, ConfirmationReference confirmationUrl, DeleteDocumentsUrl deleteDocumentsUrl, List<Signature> signatures, PAdESReference pAdESReference, Instant nextPermittedPollTime) {
+    public DirectJobStatusResponse(Long signatureJobId, String reference, DirectJobStatus signatureJobStatus, ConfirmationReference confirmationUrl, DeleteDocumentsUrl deleteDocumentsUrl, List<Signature> signatures, PAdESReference pAdESReference, Instant nextPermittedPollTime) {
         this.signatureJobId = signatureJobId;
+        this.reference = reference;
         this.status = signatureJobStatus;
         this.confirmationReference = confirmationUrl;
         this.deleteDocumentsUrl = deleteDocumentsUrl;
@@ -69,6 +71,14 @@ public class DirectJobStatusResponse implements Confirmable {
 
     public long getSignatureJobId() {
         return signatureJobId;
+    }
+
+    /**
+     * @return the signature job's custom reference as specified upon
+     * {@link DirectJob.Builder#withReference(String) creation}. May be {@code null}.
+     */
+    public String getReference() {
+        return reference;
     }
 
     public DirectJobStatus getStatus() {

--- a/src/main/java/no/digipost/signature/client/direct/JaxbEntityMapping.java
+++ b/src/main/java/no/digipost/signature/client/direct/JaxbEntityMapping.java
@@ -58,7 +58,12 @@ final class JaxbEntityMapping {
                 .map(RedirectUrl::fromJaxb)
                 .collect(toList());
 
-        return new DirectJobResponse(xmlSignatureJobResponse.getSignatureJobId(), redirectUrls, xmlSignatureJobResponse.getStatusUrl());
+        return new DirectJobResponse(
+                xmlSignatureJobResponse.getSignatureJobId(),
+                xmlSignatureJobResponse.getReference(),
+                redirectUrls,
+                xmlSignatureJobResponse.getStatusUrl()
+        );
     }
 
     static DirectJobStatusResponse fromJaxb(XMLDirectSignatureJobStatusResponse statusResponse, Instant nextPermittedPollTime) {
@@ -80,6 +85,7 @@ final class JaxbEntityMapping {
 
         return new DirectJobStatusResponse(
                 statusResponse.getSignatureJobId(),
+                statusResponse.getReference(),
                 DirectJobStatus.fromXmlType(statusResponse.getSignatureJobStatus()),
                 ConfirmationReference.of(statusResponse.getConfirmationUrl()),
                 DeleteDocumentsUrl.of(statusResponse.getDeleteDocumentsUrl()),

--- a/src/main/java/no/digipost/signature/client/portal/JaxbEntityMapping.java
+++ b/src/main/java/no/digipost/signature/client/portal/JaxbEntityMapping.java
@@ -39,7 +39,11 @@ final class JaxbEntityMapping {
     }
 
     static PortalJobResponse fromJaxb(XMLPortalSignatureJobResponse xmlPortalSignatureJobResponse) {
-        return new PortalJobResponse(xmlPortalSignatureJobResponse.getSignatureJobId(), CancellationUrl.of(xmlPortalSignatureJobResponse.getCancellationUrl()));
+        return new PortalJobResponse(
+                xmlPortalSignatureJobResponse.getSignatureJobId(),
+                xmlPortalSignatureJobResponse.getReference(),
+                CancellationUrl.of(xmlPortalSignatureJobResponse.getCancellationUrl())
+        );
     }
 
 
@@ -58,7 +62,9 @@ final class JaxbEntityMapping {
 
 
         return new PortalJobStatusChanged(
-                statusChange.getSignatureJobId(), PortalJobStatus.fromXmlType(statusChange.getStatus()),
+                statusChange.getSignatureJobId(),
+                statusChange.getReference(),
+                PortalJobStatus.fromXmlType(statusChange.getStatus()),
                 ConfirmationReference.of(statusChange.getConfirmationUrl()),
                 CancellationUrl.of(statusChange.getCancellationUrl()),
                 DeleteDocumentsUrl.of(statusChange.getDeleteDocumentsUrl()),

--- a/src/main/java/no/digipost/signature/client/portal/PortalJobResponse.java
+++ b/src/main/java/no/digipost/signature/client/portal/PortalJobResponse.java
@@ -20,15 +20,25 @@ import no.digipost.signature.client.core.internal.Cancellable;
 public class PortalJobResponse implements Cancellable {
 
     private final long signatureJobId;
+    private final String reference;
     private final CancellationUrl cancellationUrl;
 
-    public PortalJobResponse(long signatureJobId, CancellationUrl cancellationUrl) {
+    public PortalJobResponse(long signatureJobId, String reference, CancellationUrl cancellationUrl) {
         this.signatureJobId = signatureJobId;
+        this.reference = reference;
         this.cancellationUrl = cancellationUrl;
     }
 
     public long getSignatureJobId() {
         return signatureJobId;
+    }
+
+    /**
+     * @return the signature job's custom reference as specified upon
+     * {@link PortalJob.Builder#withReference(String) creation}. May be {@code null}.
+     */
+    public String getReference() {
+        return reference;
     }
 
     @Override

--- a/src/main/java/no/digipost/signature/client/portal/PortalJobStatusChanged.java
+++ b/src/main/java/no/digipost/signature/client/portal/PortalJobStatusChanged.java
@@ -44,7 +44,7 @@ public class PortalJobStatusChanged implements Confirmable, Cancellable {
      * {@link PortalJobStatusChanged}. Its status is {@link PortalJobStatus#NO_CHANGES NO_CHANGES}.
      */
     static PortalJobStatusChanged noUpdatedStatus(Instant nextPermittedPollTime) {
-        return new PortalJobStatusChanged(null, NO_CHANGES, null, null, null, null, null, nextPermittedPollTime) {
+        return new PortalJobStatusChanged(null, null, NO_CHANGES, null, null, null, null, null, nextPermittedPollTime) {
             @Override public long getSignatureJobId() {
                 throw new IllegalStateException(
                         "There were " + this + ", and querying the job ID is a programming error. " +
@@ -59,6 +59,7 @@ public class PortalJobStatusChanged implements Confirmable, Cancellable {
     }
 
     private final Long signatureJobId;
+    private final String reference;
     private final PortalJobStatus status;
     private final DeleteDocumentsUrl deleteDocumentsUrl;
     private final PAdESReference pAdESReference;
@@ -67,8 +68,9 @@ public class PortalJobStatusChanged implements Confirmable, Cancellable {
     private final List<Signature> signatures;
     private final Instant nextPermittedPollTime;
 
-    PortalJobStatusChanged(Long signatureJobId, PortalJobStatus status, ConfirmationReference confirmationReference, CancellationUrl cancellationUrl, DeleteDocumentsUrl deleteDocumentsUrl, PAdESReference pAdESReference, List<Signature> signatures, Instant nextPermittedPollTime) {
+    PortalJobStatusChanged(Long signatureJobId, String reference, PortalJobStatus status, ConfirmationReference confirmationReference, CancellationUrl cancellationUrl, DeleteDocumentsUrl deleteDocumentsUrl, PAdESReference pAdESReference, List<Signature> signatures, Instant nextPermittedPollTime) {
         this.signatureJobId = signatureJobId;
+        this.reference = reference;
         this.status = status;
         this.cancellationUrl = cancellationUrl;
         this.deleteDocumentsUrl = deleteDocumentsUrl;
@@ -80,6 +82,14 @@ public class PortalJobStatusChanged implements Confirmable, Cancellable {
 
     public long getSignatureJobId() {
         return signatureJobId;
+    }
+
+    /**
+     * @return the signature job's custom reference as specified upon
+     * {@link PortalJob.Builder#withReference(String) creation}. May be {@code null}.
+     */
+    public String getReference() {
+        return reference;
     }
 
     public PortalJobStatus getStatus() {


### PR DESCRIPTION
Dette kan være nyttig hvis klienter ikke ønsker å ta vare på IDen som
returneres fra tjenesten, men heller vil bruke sin interne referanse.

Avhengig av https://github.com/digipost/signature-api-specification/pull/84