### PR TITLE
Lenker til den nye dokumentasjonen

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repo is the Java client library for integrating with Posten signering. Plea
 
 ## 📕 Documentation
 
-Integration guide can be found at [digipost.github.io/signature-api-client-java](http://digipost.github.io/signature-api-client-java).
+Get started by [reading the documentation](http://signering-docs.rtfd.io/).
 
 For a detailed API specification, please see [Signature-API-Specification](https://github.com/digipost/signature-api-specification).
 


### PR DESCRIPTION
### 💰 Funksjonell beskrivelse av endringen

Vi har startet å bruke Read The Docs. Nå lenker vi dit i stedet for til den gamle dokumentasjonen.