### PR TITLE
Endrer Useragent

### DIFF
--- a/src/main/java/no/digipost/signature/client/ClientConfiguration.java
+++ b/src/main/java/no/digipost/signature/client/ClientConfiguration.java
@@ -60,7 +60,7 @@ public final class ClientConfiguration implements ProvidesCertificateResourcePat
      * The {@link HttpHeaders#USER_AGENT User-Agent} header which will be included in all requests. You may include a custom part
      * using {@link Builder#includeInUserAgent(String)}.
      */
-    public static final String MANDATORY_USER_AGENT = "digipost-signature-api-client-java/" + VERSION + " (" + JAVA_DESCRIPTION + ")";
+    public static final String MANDATORY_USER_AGENT = "posten-signature-api-client-java/" + VERSION + " (" + JAVA_DESCRIPTION + ")";
 
     /**
      * {@value #HTTP_REQUEST_RESPONSE_LOGGER_NAME} is the name of the logger which will log the HTTP requests and responses,

--- a/src/main/java/no/digipost/signature/client/ClientConfiguration.java
+++ b/src/main/java/no/digipost/signature/client/ClientConfiguration.java
@@ -60,7 +60,7 @@ public final class ClientConfiguration implements ProvidesCertificateResourcePat
      * The {@link HttpHeaders#USER_AGENT User-Agent} header which will be included in all requests. You may include a custom part
      * using {@link Builder#includeInUserAgent(String)}.
      */
-    public static final String MANDATORY_USER_AGENT = "Posten signering Java API Client/" + VERSION + " (" + JAVA_DESCRIPTION + ")";
+    public static final String MANDATORY_USER_AGENT = "digipost-signature-api-client-java/" + VERSION + " (" + JAVA_DESCRIPTION + ")";
 
     /**
      * {@value #HTTP_REQUEST_RESPONSE_LOGGER_NAME} is the name of the logger which will log the HTTP requests and responses,


### PR DESCRIPTION
I klientbiblioteket for C#/.NET så har vi
digipost-signature-api-client-dotnet. Tenker det er fint at det er likt.
Jeg synes det er litt underlig at det heter _digipost først_, så for min
del kan det godt sløyfes.

Problemet med at de er så forskjellige nå er at jeg trodde det ikke
logges. Jeg søkte etter signature-api-client og trodde jeg skulle få
requester gjort med Java-klienten, men det gjorde jeg ikke.

Vad tycks?