### PR TITLE
More appropriate interface for generating signature

### DIFF
--- a/.travis.maven.settings.xml
+++ b/.travis.maven.settings.xml
@@ -1,0 +1,12 @@
+<settings
+    xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+    <servers>
+        <server>
+            <id>sonatype-oss-nexus-snapshots</id>
+            <username>${env.SONATYPE_USER}</username>
+            <password>${env.SONATYPE_PASS}</password>
+        </server>
+    </servers>
+</settings>

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,25 @@
-sudo: false
-cache:
-  directories:
-    - '$HOME/.m2/repository'
-
+dist: trusty
 language: java
 jdk:
-  - oraclejdk8
+- oraclejdk8
+- openjdk11
+- openjdk12
+
+cache:
+  directories:
+  - $HOME/.m2
 
 env:
   global:
   - secure: "Pxgdes5ypkne3eAtpRYS+bPiKTu2XLa8ECRR0g2/1XeO8VcLrkuPTA3R//U3tOX2lvi0sH5QMyBONkSyDemhh7+Mcc0m8UgG/efOHncJ5HgGjsgZdjOnMcrSATjBM9Owx4ERjCm/exGkBv35pWWFtVPxpzKTJ114c/vekJAnAill/YgAw1s2eNPzxMqBYv3fdGfbwxcEQh+6LDmPv0iBD6s4zOOdOnHa/ZQa8+xLRUP4cyWI+TsNwdD7iBU9dA85P4KBPAT+/aCiRzRNJHfz4mzIM23gKrk1xEbf5kNT2EyIYoyPWVYZCjV+E7TzNJXUVxj3AJo1APfg2FU5WRTfv1MwqyRQI9Ulmfwjsl33Bbo/Uo9hs26AIqwRN9uoPO+DJuFYD+u36t8K8GsY3yQWf2pj+t17sDyzAUeeAW6T7RdIFpQFO6bgMeYG69C1eR/W+wG66dVPcGdOcdxi37o0pqnh1HxlyhlSHfpNLuapo62WfoBA0VzynHCHtc5tmzx64FsdMJ6DJEGIOndmgaq5OvxzlMlQBXqwz8QZLKTAqds+StAeDxHLywZeg4sbWY87/t+WkL672xxJVh4rVvcpxHk7eo/0ne9Bou1yaE/09v360f6SRxNp/q5jJPC1nGivDVKmmwM2vJFEaCfK4wcrsTicZe7Qg2FNZxCvOlC1D9M="
   - secure: "ZAO/ED59fybplawhIWyOTtZJExElb5FzKYoZwBFxGrrQKi00IPfHYvIdXImD6bbZfCwfBTuunXxGvMRrK5yWqPFGzjXkt3PCGizbDTlMtnTXbMmRW65ZQx6PnNwAP9l30NPv5AVwemDLGiLqF61+N2O18WZ/6dWUDyE/dh477D6eC30EceDwZN1RVvP0BrP6xSixRQC7arE5AlY9F0YEsVA6gIi6jQEW7VSJXAvc1uNP5DdGy1FFhAIvJ0d/se8M90Imn/AoHOWD4ZcXhQ0GYYMzUxuW98GsXwVkpd2nIrJHK3nUq6UVQSsFUZGdgtk+JiYJwNFoSgFrQelXm3pYi5lbCoSyeMNEcnOu2njz1nwmWThKo++aN55yGQcCcTjMrpswBo7I0jfaWa2I9kQ9/vpCOlVBqLGZBZRfQsnMevIR5VNuMDTnuDLFKPQLVrrEdEDNx47KXMiS3qzDCxuXotzr/Lg9rnCVj9RunwZJ46zy1n/F4Em1XNiOcoXvWvwkInxU3L+eHLur+8mDUVmxf5iYXPRyEMFYTExqwx6VZlE6W786OnJrR3Dnp9Rv57VYShn4HOwjCaoy9XYHvXB12lh0xY129R52qYCBLrTDj3w6iRYW0gGWoWFxTZDehu42sNPNDx6xTHtkjpP1UBVMsVmiypc1SpLoCJDGCxlccbw="
 
-before_install:
-  - echo "<settings><servers><server><id>sonatype-oss-nexus-snapshots</id><username>\${env.SONATYPE_USER}</username><password>\${env.SONATYPE_PASS}</password></server></servers></settings>" > ~/.m2/deploy-settings.xml
+install: true
 
-install:
-  - export mavenBuildGoal="$([[ ${TRAVIS_TAG} == '' ]] && echo deploy || echo verify)"
-  - echo "Maven will ${mavenBuildGoal}"
-  - mvn clean ${mavenBuildGoal} -U --settings ~/.m2/deploy-settings.xml
+before_script:
+  - cp .travis.maven.settings.xml ~/.m2/settings.xml
 
 script:
-  - echo "no build script"
+  - 'echo "TRAVIS_PULL_REQUEST value: $TRAVIS_PULL_REQUEST"'
+  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then mvn clean deploy --update-snapshots; fi'
+  - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then mvn clean install --update-snapshots; fi' #Uses !="false" because $TRAVIS_PULL_REQUEST is the Pull Request number if such is the case.

--- a/NOTICE
+++ b/NOTICE
@@ -17,12 +17,11 @@ This software includes third party software subject to the following licenses:
   istack common utility code runtime under Eclipse Distribution License - v 1.0
   jakarta.annotation API under EPL 2.0 or GPL2 w/ CPE
   jakarta.xml.bind-api under Eclipse Distribution License - v 1.0
-  JavaBeans Activation Framework API jar under CDDL/GPLv2+CE
+  JavaBeans Activation Framework API jar under EDL 1.0
   javax.annotation API under CDDL + GPLv2 with classpath exception
   javax.inject:1 as OSGi bundle under EPL 2.0 or GPL2 w/ CPE
   javax.ws.rs-api under EPL 2.0 or GPL2 w/ CPE
   JAXB Runtime under Eclipse Distribution License - v 1.0
-  jaxb-api under CDDL 1.1 or GPL2 w/ CPE
   JAXB2 Basics - Runtime under BSD-Style License
   JCL 1.2 implemented over SLF4J under MIT License
   jersey-core-client under EPL 2.0 or GPL2 w/ CPE or EDL 1.0 or BSD 2-Clause or Apache License, 2.0 or Public Domain or Modified BSD or jQuery license or MIT license or W3C license

--- a/NOTICE
+++ b/NOTICE
@@ -18,7 +18,6 @@ This software includes third party software subject to the following licenses:
   jakarta.annotation API under EPL 2.0 or GPL2 w/ CPE
   jakarta.xml.bind-api under Eclipse Distribution License - v 1.0
   JavaBeans Activation Framework API jar under EDL 1.0
-  javax.annotation API under CDDL + GPLv2 with classpath exception
   javax.inject:1 as OSGi bundle under EPL 2.0 or GPL2 w/ CPE
   javax.ws.rs-api under EPL 2.0 or GPL2 w/ CPE
   JAXB Runtime under Eclipse Distribution License - v 1.0

--- a/pom.xml
+++ b/pom.xml
@@ -77,9 +77,9 @@
             <version>4.4.11</version>
         </dependency>
         <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
-            <version>1.3.2</version>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <version>1.3.4</version>
         </dependency>
         <dependency>
             <groupId>javax.ws.rs</groupId>
@@ -300,6 +300,7 @@
                             <bannedDependencies>
                                 <excludes>
                                     <exclude>commons-logging</exclude>
+                                    <exclude>javax.annotation</exclude>
                                 </excludes>
                                 <searchTransitive>true</searchTransitive>
                             </bannedDependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-framework-bom</artifactId>
-                <version>5.1.5.RELEASE</version>
+                <version>5.1.6.RELEASE</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.7</version>
+            <version>4.5.8</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <name>Posten signering - Java API Client Library</name>
     <groupId>no.digipost.signature</groupId>
     <artifactId>signature-api-client-java</artifactId>
-    <version>4.6-SNAPSHOT</version>
+    <version>4.6</version>
 
     <parent>
         <groupId>no.digipost</groupId>
@@ -357,7 +357,7 @@
         <connection>scm:git:git@github.com:digipost/signature-api-client-java.git</connection>
         <developerConnection>scm:git:git@github.com:digipost/signature-api-client-java.git</developerConnection>
         <url>https://github.com/digipost/signature-api-client-java/</url>
-        <tag>HEAD</tag>
+        <tag>4.6</tag>
     </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -241,7 +241,7 @@
                 <plugin>
                     <groupId>com.github.siom79.japicmp</groupId>
                     <artifactId>japicmp-maven-plugin</artifactId>
-                    <version>0.13.0</version>
+                    <version>0.13.1</version>
                     <configuration>
                         <newVersion>
                             <file>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <name>Posten signering - Java API Client Library</name>
     <groupId>no.digipost.signature</groupId>
     <artifactId>signature-api-client-java</artifactId>
-    <version>4.6</version>
+    <version>4.7-SNAPSHOT</version>
 
     <parent>
         <groupId>no.digipost</groupId>
@@ -357,7 +357,7 @@
         <connection>scm:git:git@github.com:digipost/signature-api-client-java.git</connection>
         <developerConnection>scm:git:git@github.com:digipost/signature-api-client-java.git</developerConnection>
         <url>https://github.com/digipost/signature-api-client-java/</url>
-        <tag>4.6</tag>
+        <tag>HEAD</tag>
     </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -82,9 +82,9 @@
             <version>1.3.4</version>
         </dependency>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
-            <version>2.1.1</version>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+            <version>2.1.5</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jaxb</groupId>
@@ -301,6 +301,7 @@
                                 <excludes>
                                     <exclude>commons-logging</exclude>
                                     <exclude>javax.annotation</exclude>
+                                    <exclude>javax.ws.rs</exclude>
                                 </excludes>
                                 <searchTransitive>true</searchTransitive>
                             </bannedDependencies>
@@ -313,7 +314,6 @@
                             </requireMavenVersion>
                         </rules>
                     </configuration>
-
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,8 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <signature.api.version>2.5</signature.api.version>
-        <slf4j.version>1.7.25</slf4j.version>
+        <signature.api.version>2.6</signature.api.version>
+        <slf4j.version>1.7.26</slf4j.version>
     </properties>
 
     <dependencyManagement>
@@ -113,7 +113,7 @@
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.11</version>
+            <version>1.12</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
@@ -126,7 +126,7 @@
         <dependency>
             <groupId>org.springframework.ws</groupId>
             <artifactId>spring-xml</artifactId>
-            <version>3.0.6.RELEASE</version>
+            <version>3.0.7.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -173,7 +173,7 @@
         <dependency>
             <groupId>nl.jqno.equalsverifier</groupId>
             <artifactId>equalsverifier</artifactId>
-            <version>3.1.4</version>
+            <version>3.1.7</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -228,9 +228,9 @@
                             <version>2.3.2</version>
                         </dependency>
                         <dependency>
-                            <groupId>javax.xml.bind</groupId>
-                            <artifactId>jaxb-api</artifactId>
-                            <version>2.3.1</version>
+                            <groupId>jakarta.xml.bind</groupId>
+                            <artifactId>jakarta.xml.bind-api</artifactId>
+                            <version>2.3.2</version>
                         </dependency>
                     </dependencies>
                 </plugin>

--- a/src/main/java/no/digipost/signature/client/asice/ASiCEAttachable.java
+++ b/src/main/java/no/digipost/signature/client/asice/ASiCEAttachable.java
@@ -1,9 +1,19 @@
 package no.digipost.signature.client.asice;
 
-public interface ASiCEAttachable {
+import no.digipost.signature.client.asice.signature.SignableFileReference;
+
+import static org.apache.commons.codec.digest.DigestUtils.sha256;
+
+public interface ASiCEAttachable extends SignableFileReference {
+    @Override
     String getFileName();
 
     byte[] getBytes();
 
     String getMimeType();
+
+    @Override
+    default byte[] getSha256() {
+        return sha256(getBytes());
+    }
 }

--- a/src/main/java/no/digipost/signature/client/asice/signature/CreateSignature.java
+++ b/src/main/java/no/digipost/signature/client/asice/signature/CreateSignature.java
@@ -1,6 +1,5 @@
 package no.digipost.signature.client.asice.signature;
 
-import no.digipost.signature.client.asice.ASiCEAttachable;
 import no.digipost.signature.client.core.exceptions.ConfigurationException;
 import no.digipost.signature.client.core.exceptions.XmlConfigurationException;
 import no.digipost.signature.client.core.exceptions.XmlValidationException;
@@ -50,7 +49,6 @@ import java.util.List;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
-import static org.apache.commons.codec.digest.DigestUtils.sha256;
 
 @SuppressWarnings("FieldCanBeLocal")
 public class CreateSignature {
@@ -94,7 +92,7 @@ public class CreateSignature {
         }
     }
 
-    public Signature createSignature(final List<ASiCEAttachable> attachedFiles, final KeyStoreConfig keyStoreConfig) {
+    public Signature createSignature(final List<? extends SignableFileReference> attachedFiles, final KeyStoreConfig keyStoreConfig) {
         XMLSignatureFactory xmlSignatureFactory = getSignatureFactory();
         SignatureMethod signatureMethod = getSignatureMethod(xmlSignatureFactory);
 
@@ -164,13 +162,13 @@ public class CreateSignature {
         }
     }
 
-    private List<Reference> references(final XMLSignatureFactory xmlSignatureFactory, final List<ASiCEAttachable> files) {
+    private List<Reference> references(final XMLSignatureFactory xmlSignatureFactory, final List<? extends SignableFileReference> files) {
         List<Reference> result = new ArrayList<>();
         for (int i = 0; i < files.size(); i++) {
             try {
                 String signatureElementId = "ID_" + i;
                 String uri = URLEncoder.encode(files.get(i).getFileName(), "UTF-8");
-                Reference reference = xmlSignatureFactory.newReference(uri, sha256DigestMethod, null, null, signatureElementId, sha256(files.get(i).getBytes()));
+                Reference reference = xmlSignatureFactory.newReference(uri, sha256DigestMethod, null, null, signatureElementId, files.get(i).getSha256());
                 result.add(reference);
             } catch(UnsupportedEncodingException e) {
                 throw new RuntimeException(e);

--- a/src/main/java/no/digipost/signature/client/asice/signature/CreateSignature.java
+++ b/src/main/java/no/digipost/signature/client/asice/signature/CreateSignature.java
@@ -93,6 +93,10 @@ public class CreateSignature {
     }
 
     public Signature createSignature(final List<? extends SignableFileReference> attachedFiles, final KeyStoreConfig keyStoreConfig) {
+        return new Signature(domUtils.serializeToXml(createXmlSignature(attachedFiles, keyStoreConfig)));
+    }
+
+    protected Document createXmlSignature(final List<? extends SignableFileReference> attachedFiles, final KeyStoreConfig keyStoreConfig) {
         XMLSignatureFactory xmlSignatureFactory = getSignatureFactory();
         SignatureMethod signatureMethod = getSignatureMethod(xmlSignatureFactory);
 
@@ -138,7 +142,7 @@ public class CreateSignature {
                     "Verify that the input is valid and that there are no illegal symbols in file names etc.", e);
         }
 
-        return new Signature(domUtils.serializeToXml(signedDocument));
+        return signedDocument;
     }
 
     private URIDereferencer signedPropertiesURIDereferencer(XAdESArtifacts xadesArtifacts, XMLSignatureFactory signatureFactory) {

--- a/src/main/java/no/digipost/signature/client/asice/signature/CreateXAdESArtifacts.java
+++ b/src/main/java/no/digipost/signature/client/asice/signature/CreateXAdESArtifacts.java
@@ -10,7 +10,6 @@ import no.digipost.signature.api.xml.thirdparty.xades.SignedSignatureProperties;
 import no.digipost.signature.api.xml.thirdparty.xades.SigningCertificate;
 import no.digipost.signature.api.xml.thirdparty.xmldsig.DigestMethod;
 import no.digipost.signature.api.xml.thirdparty.xmldsig.X509IssuerSerialType;
-import no.digipost.signature.client.asice.ASiCEAttachable;
 import no.digipost.signature.client.core.exceptions.CertificateException;
 
 import java.security.cert.CertificateEncodingException;
@@ -36,7 +35,7 @@ class CreateXAdESArtifacts {
         this.clock = clock;
     }
 
-    XAdESArtifacts createArtifactsToSign(List<ASiCEAttachable> files, X509Certificate certificate) {
+    XAdESArtifacts createArtifactsToSign(List<? extends SignableFileReference> files, X509Certificate certificate) {
         byte[] certificateDigestValue;
         try {
             certificateDigestValue = sha1(certificate.getEncoded());
@@ -57,7 +56,7 @@ class CreateXAdESArtifacts {
         return XAdESArtifacts.from(qualifyingProperties);
     }
 
-    private List<DataObjectFormat> dataObjectFormats(List<ASiCEAttachable> files) {
+    private List<DataObjectFormat> dataObjectFormats(List<? extends SignableFileReference> files) {
         List<DataObjectFormat> result = new ArrayList<>();
         for (int i = 0; i < files.size(); i++) {
             String signatureElementIdReference = format("#ID_%s", i);

--- a/src/main/java/no/digipost/signature/client/asice/signature/SignableFileReference.java
+++ b/src/main/java/no/digipost/signature/client/asice/signature/SignableFileReference.java
@@ -1,0 +1,11 @@
+package no.digipost.signature.client.asice.signature;
+
+public interface SignableFileReference {
+
+    String getFileName();
+
+    byte[] getSha256();
+
+    String getMimeType();
+
+}


### PR DESCRIPTION
The `ASiCEAttachable` is not a perfect fit for the input for the xml signature generation in `CreateSignature`. This pull request introduces a new interface `SignableFileReference` which exposes the actual data needed for the signature. ASiCEAttachable extends this interface, and provides a default implementation for the new `getSha256`-method, preserving backwards compatibility.

This simplifies the use of `CreateSignature` in isolation (e.g. in tests), as it is more explicit what is really needed as input for the signature generation.
