### PR TITLE
Legger til Confirm til eksempler for uthenting av status

### DIFF
--- a/src/test/java/no/digipost/signature/client/docs/PortalClientUseCases.java
+++ b/src/test/java/no/digipost/signature/client/docs/PortalClientUseCases.java
@@ -50,11 +50,13 @@ class PortalClientUseCases {
             // Queue is empty. Must wait before polling again
             Instant nextPermittedPollTime = statusChange.getNextPermittedPollTime();
         } else {
-            // Recieved status update, act according to status
+            // Received status update, act according to status
             PortalJobStatus signatureJobStatus = statusChange.getStatus();
             Instant nextPermittedPollTime = statusChange.getNextPermittedPollTime();
         }
 
+        //Confirm the receipt to remove it from the queue
+        client.confirm(statusChange);
     }
 
     static void get_signer_status() {
@@ -87,13 +89,6 @@ class PortalClientUseCases {
         if (signature.is(SignatureStatus.SIGNED)) {
             InputStream xAdESStream = client.getXAdES(signature.getxAdESUrl());
         }
-    }
-
-    static void confirm_processed_signature_job() {
-        PortalClient client = null; // As initialized earlier
-        PortalJobStatusChanged statusChange = null; // As returned when polling for status changes
-
-        client.confirm(statusChange);
     }
 
     static void specifying_queues() {

--- a/src/test/java/no/digipost/signature/client/docs/PortalClientUseCases.java
+++ b/src/test/java/no/digipost/signature/client/docs/PortalClientUseCases.java
@@ -55,16 +55,13 @@ class PortalClientUseCases {
             Instant nextPermittedPollTime = statusChange.getNextPermittedPollTime();
         }
 
-        //Confirm the receipt to remove it from the queue
-        client.confirm(statusChange);
-    }
-
-    static void get_signer_status() {
-        PortalJobStatusChanged statusChange = null; // As returned when polling for status changes
-
+        //Get status for signer
         Signature signature = statusChange.getSignatureFrom(
                 SignerIdentifier.identifiedByPersonalIdentificationNumber("12345678910")
         );
+
+        //Confirm the receipt to remove it from the queue
+        client.confirm(statusChange);
     }
 
     static void get_signed_documents() {


### PR DESCRIPTION
### 💰 Funksjonell beskrivelse av endringen

Fordi de som integrerer glemmer det av. Henger sammen med oppdatering av dokumentasjon for Signering - digipost/signering-docs#23. Tar i tillegg inn et eksempel for uthenting av status for undertegner som ikke ble brukt i dokumentasjonen.