### PR TITLE
Rename document owner to archive owner

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -22,7 +22,7 @@ This software includes third party software subject to the following licenses:
   javax.inject:1 as OSGi bundle under EPL 2.0 or GPL2 w/ CPE
   JAXB Runtime under Eclipse Distribution License - v 1.0
   JAXB2 Basics - Runtime under BSD-Style License
-  JCL 1.2 implemented over SLF4J under MIT License
+  JCL 1.2 implemented over SLF4J under Apache License, Version 2.0
   jersey-core-client under EPL 2.0 or GPL2 w/ CPE or EDL 1.0 or BSD 2-Clause or Apache License, 2.0 or Public Domain or Modified BSD or jQuery license or MIT license or W3C license
   jersey-core-common under EPL 2.0 or The GNU General Public License (GPL), Version 2, With Classpath Exception or Apache License, 2.0 or Public Domain
   jersey-media-multipart under EPL 2.0 or GPL2 w/ CPE or EDL 1.0 or BSD 2-Clause or Apache License, 2.0 or Public Domain or Modified BSD or jQuery license or MIT license or W3C license

--- a/pom.xml
+++ b/pom.xml
@@ -242,7 +242,7 @@
                 <plugin>
                     <groupId>com.github.siom79.japicmp</groupId>
                     <artifactId>japicmp-maven-plugin</artifactId>
-                    <version>0.14.1</version>
+                    <version>0.14.2</version>
                     <configuration>
                         <newVersion>
                             <file>
@@ -263,7 +263,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.0.0-M3</version>
+                    <version>3.0.0-M4</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-deploy-plugin</artifactId>
@@ -295,11 +295,11 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.1.2</version>
+                    <version>3.2.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>3.0.0-M2</version>
+                    <version>3.0.0-M3</version>
                     <configuration>
                         <rules>
                             <bannedDependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -10,14 +10,14 @@
     <parent>
         <groupId>no.digipost</groupId>
         <artifactId>digipost-open-super-pom</artifactId>
-        <version>6</version>
+        <version>7</version>
     </parent>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <signature.api.version>2.7</signature.api.version>
-        <slf4j.version>1.7.28</slf4j.version>
+        <slf4j.version>1.7.29</slf4j.version>
     </properties>
 
     <dependencyManagement>
@@ -25,7 +25,7 @@
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-framework-bom</artifactId>
-                <version>5.2.0.RELEASE</version>
+                <version>5.2.1.RELEASE</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -124,7 +124,7 @@
         <dependency>
             <groupId>org.springframework.ws</groupId>
             <artifactId>spring-xml</artifactId>
-            <version>3.0.7.RELEASE</version>
+            <version>3.0.8.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -193,7 +193,7 @@
         <dependency>
             <groupId>no.digipost</groupId>
             <artifactId>digg</artifactId>
-            <version>0.20</version>
+            <version>0.22</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/no/digipost/signature/client/archive/ArchiveClient.java
+++ b/src/main/java/no/digipost/signature/client/archive/ArchiveClient.java
@@ -15,7 +15,8 @@ public class ArchiveClient {
         this.client = new ClientHelper(SignatureHttpClientFactory.create(httpIntegrationConfig), Optional.empty());
     }
 
-    public InputStream getPAdES(DocumentOwner owner, String id) {
+    public InputStream getPAdES(ArchiveOwner owner, String id) {
         return client.getDataStream(root -> root.path(owner.getOrganizationNumber()).path("archive/documents/").path(id).path("pades"));
     }
+
 }

--- a/src/main/java/no/digipost/signature/client/archive/ArchiveOwner.java
+++ b/src/main/java/no/digipost/signature/client/archive/ArchiveOwner.java
@@ -2,20 +2,20 @@ package no.digipost.signature.client.archive;
 
 import no.digipost.signature.client.core.WithOrganizationNumber;
 
-public final class DocumentOwner implements WithOrganizationNumber {
+public final class ArchiveOwner implements WithOrganizationNumber {
 
-    public static DocumentOwner of(WithOrganizationNumber organization) {
+    public static ArchiveOwner of(WithOrganizationNumber organization) {
         return ofOrganizationNumber(organization.getOrganizationNumber());
     }
 
-    public static DocumentOwner ofOrganizationNumber(String organizationNumber) {
-        return new DocumentOwner(organizationNumber);
+    public static ArchiveOwner ofOrganizationNumber(String organizationNumber) {
+        return new ArchiveOwner(organizationNumber);
     }
 
 
     private final String organizationNumber;
 
-    private DocumentOwner(String organizationNumber) {
+    private ArchiveOwner(String organizationNumber) {
         this.organizationNumber = organizationNumber;
     }
 


### PR DESCRIPTION
Speaking of an archive owner is more correct than a document owner, as
the document is not necessarily "owned" as such by an organization having access
to download it. Conceptually the document is _contained_ in an archive
owned by an organization, an ArchiveOwner.

