### PR TITLE
Just single document in direct job API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <signature.api.version>oppdragstittel-SNAPSHOT</signature.api.version>
+        <signature.api.version>multiple-documents-with-legacy-single-document-support-SNAPSHOT</signature.api.version>
         <slf4j.version>1.7.29</slf4j.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <signature.api.version>multiple-documents-with-legacy-single-document-support-SNAPSHOT</signature.api.version>
+        <signature.api.version>oppdragstittel-SNAPSHOT</signature.api.version>
         <slf4j.version>1.7.29</slf4j.version>
     </properties>
 

--- a/src/main/java/no/digipost/signature/client/asice/manifest/CreateDirectManifest.java
+++ b/src/main/java/no/digipost/signature/client/asice/manifest/CreateDirectManifest.java
@@ -40,7 +40,7 @@ public class CreateDirectManifest extends ManifestCreator<DirectJob> {
                 .withSigners(signers)
                 .withRequiredAuthentication(job.getRequiredAuthentication().map(AuthenticationLevel::getXmlEnumValue).orElse(null))
                 .withSender(new XMLSender().withOrganizationNumber(sender.getOrganizationNumber()))
-                .withDocuments(new XMLDirectDocument()
+                .withDocument(new XMLDirectDocument()
                         .withTitle(document.getTitle())
                         .withDescription(document.getMessage())
                         .withHref(XMLHref.of(document.getFileName()))


### PR DESCRIPTION
Following https://github.com/digipost/signature-api-specification/pull/191, the direct flow API only supports a single document, but is intended to transition to support multiple documents in the future. So this PR removes the plural 's' from a method call 😛 