### PR TITLE
Support multiple documents for direct jobs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.previousVersion>set_with_-Dproject.previousVersion=X.Y</project.previousVersion>
-        <signature.api.version>2.8-RC1</signature.api.version>
+        <signature.api.version>multiple-documents-SNAPSHOT</signature.api.version>
         <slf4j.version>1.7.30</slf4j.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.previousVersion>set_with_-Dproject.previousVersion=X.Y</project.previousVersion>
-        <signature.api.version>multiple-documents-SNAPSHOT</signature.api.version>
+        <signature.api.version>2.8-RC2</signature.api.version>
         <slf4j.version>1.7.30</slf4j.version>
     </properties>
 

--- a/src/main/java/no/digipost/signature/client/asice/manifest/CreateDirectManifest.java
+++ b/src/main/java/no/digipost/signature/client/asice/manifest/CreateDirectManifest.java
@@ -16,12 +16,13 @@ import no.digipost.signature.client.direct.DirectSigner;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class CreateDirectManifest extends ManifestCreator<DirectJob> {
 
     @Override
     Object buildXmlManifest(DirectJob job, Sender sender) {
-        DirectDocument document = job.getDocument();
+        List<DirectDocument> documents = job.getDocuments();
 
         List<XMLDirectSigner> signers = new ArrayList<>();
         for (DirectSigner signer : job.getSigners()) {
@@ -40,11 +41,14 @@ public class CreateDirectManifest extends ManifestCreator<DirectJob> {
                 .withSigners(signers)
                 .withRequiredAuthentication(job.getRequiredAuthentication().map(AuthenticationLevel::getXmlEnumValue).orElse(null))
                 .withSender(new XMLSender().withOrganizationNumber(sender.getOrganizationNumber()))
-                .withDocument(new XMLDirectDocument()
-                        .withTitle(document.getTitle())
-                        .withDescription(document.getMessage())
-                        .withHref(XMLHref.of(document.getFileName()))
-                        .withMime(document.getMimeType())
+                .withTitle(job.getTitle())
+                .withDescription(job.getDescription().orElse(null))
+                .withDocuments(documents.stream().map(document ->
+                            new XMLDirectDocument()
+                                    .withTitle(document.getTitle())
+                                    .withHref(XMLHref.of(document.getFileName()))
+                                    .withMime(document.getMimeType())
+                    ).collect(Collectors.toList())
                 )
                 .withIdentifierInSignedDocuments(job.getIdentifierInSignedDocuments().map(IdentifierInSignedDocuments::getXmlEnumValue).orElse(null))
                 ;

--- a/src/main/java/no/digipost/signature/client/direct/DirectDocument.java
+++ b/src/main/java/no/digipost/signature/client/direct/DirectDocument.java
@@ -6,19 +6,12 @@ import static no.digipost.signature.client.core.Document.FileType.PDF;
 
 public class DirectDocument extends Document {
 
-    private final String message;
-
-    private DirectDocument(String title, String message, String fileName, FileType fileType, byte[] document) {
+    private DirectDocument(String title, String fileName, FileType fileType, byte[] document) {
         super(title, fileName, fileType, document);
-        this.message = message;
     }
 
     public static Builder builder(final String title, final String fileName, final byte[] document) {
         return new Builder(title, fileName, document);
-    }
-
-    public String getMessage() {
-        return message;
     }
 
     public static class Builder {
@@ -26,7 +19,6 @@ public class DirectDocument extends Document {
         private String title;
         private String fileName;
         private byte[] document;
-        private String message;
         private FileType fileType = PDF;
 
         public Builder(final String title, final String fileName, final byte[] document) {
@@ -35,18 +27,13 @@ public class DirectDocument extends Document {
             this.document = document;
         }
 
-        public Builder message(String message) {
-            this.message = message;
-            return this;
-        }
-
         public Builder fileType(final FileType fileType) {
             this.fileType = fileType;
             return this;
         }
 
         public DirectDocument build() {
-            return new DirectDocument(title, message, fileName, fileType, document);
+            return new DirectDocument(title, fileName, fileType, document);
         }
     }
 }

--- a/src/main/java/no/digipost/signature/client/direct/DirectJob.java
+++ b/src/main/java/no/digipost/signature/client/direct/DirectJob.java
@@ -12,7 +12,9 @@ public class DirectJob implements SignatureJob, WithExitUrls {
 
     private String reference;
     private List<DirectSigner> signers;
-    private DirectDocument document;
+    private List<DirectDocument> documents;
+    private String title;
+    private Optional<String> description = Optional.empty();
     private URI completionUrl;
     private URI rejectionUrl;
     private URI errorUrl;
@@ -21,9 +23,10 @@ public class DirectJob implements SignatureJob, WithExitUrls {
     private Optional<AuthenticationLevel> requiredAuthentication = Optional.empty();
     private Optional<IdentifierInSignedDocuments> identifierInSignedDocuments = Optional.empty();
 
-    private DirectJob(List<DirectSigner> signers, DirectDocument document, URI completionUrl, URI rejectionUrl, URI errorUrl) {
+    private DirectJob(String title, List<DirectSigner> signers, List<DirectDocument> documents, URI completionUrl, URI rejectionUrl, URI errorUrl) {
+        this.title = title;
         this.signers = unmodifiableList(new ArrayList<>(signers));
-        this.document = document;
+        this.documents = unmodifiableList(new ArrayList<>(documents));
         this.completionUrl = completionUrl;
         this.rejectionUrl = rejectionUrl;
         this.errorUrl = errorUrl;
@@ -35,13 +38,8 @@ public class DirectJob implements SignatureJob, WithExitUrls {
     }
 
     @Override
-    public DirectDocument getDocument() {
-        return document;
-    }
-
-    @Override
-    public List<? extends Document> getDocuments() {
-        return unmodifiableList(Collections.singletonList(document));
+    public List<DirectDocument> getDocuments() {
+        return documents;
     }
 
     @Override
@@ -93,12 +91,11 @@ public class DirectJob implements SignatureJob, WithExitUrls {
      * @param signers     The {@link DirectSigner DirectSigners} of the document.
      *
      * @return a builder to further customize the job
-     * @see DirectJob#builder(DirectDocument, WithExitUrls, List)
+     * @see DirectJob#builder(String, DirectDocument, WithExitUrls, List)
      */
-    public static Builder builder(DirectDocument document, WithExitUrls hasExitUrls, DirectSigner... signers) {
-        return builder(document, hasExitUrls, Arrays.asList(signers));
+    public static Builder builder(String title, DirectDocument document, WithExitUrls hasExitUrls, DirectSigner... signers) {
+        return builder(title, Collections.singletonList(document), hasExitUrls, Arrays.asList(signers));
     }
-
 
     /**
      * Create a new DirectJob.
@@ -110,24 +107,42 @@ public class DirectJob implements SignatureJob, WithExitUrls {
      * @param signers     The {@link DirectSigner DirectSigners} of the document.
      *
      * @return a builder to further customize the job
-     * @see DirectJob#builder(DirectDocument, WithExitUrls, DirectSigner...)
+     * @see DirectJob#builder(String, DirectDocument, WithExitUrls, DirectSigner...)
      */
-    public static Builder builder(DirectDocument document, WithExitUrls hasExitUrls, List<DirectSigner> signers) {
-        return new Builder(signers, document, hasExitUrls.getCompletionUrl(), hasExitUrls.getRejectionUrl(), hasExitUrls.getErrorUrl());
+    public static Builder builder(String title, DirectDocument document, WithExitUrls hasExitUrls, List<DirectSigner> signers) {
+        return new Builder(title, signers, Collections.singletonList(document), hasExitUrls.getCompletionUrl(), hasExitUrls.getRejectionUrl(), hasExitUrls.getErrorUrl());
     }
+
+    public static Builder builder(String title, List<DirectDocument> documents, WithExitUrls hasExitUrls, List<DirectSigner> signers) {
+        return new Builder(title, signers, documents, hasExitUrls.getCompletionUrl(), hasExitUrls.getRejectionUrl(), hasExitUrls.getErrorUrl());
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public Optional<String> getDescription() {
+        return description;
+    }
+
 
     public static class Builder implements JobCustomizations<Builder> {
 
         private final DirectJob target;
         private boolean built = false;
 
-        private Builder(List<DirectSigner> signers, DirectDocument document, URI completionUrl, URI rejectionUrl, URI errorUrl) {
-            target = new DirectJob(signers, document, completionUrl, rejectionUrl, errorUrl);
+        private Builder(String title, List<DirectSigner> signers, List<DirectDocument> documents, URI completionUrl, URI rejectionUrl, URI errorUrl) {
+            target = new DirectJob(title, signers, documents, completionUrl, rejectionUrl, errorUrl);
         }
 
         @Override
         public Builder withReference(UUID uuid) {
             return withReference(uuid.toString());
+        }
+
+        public Builder withDescription(String description) {
+            target.description = Optional.of(description);
+            return this;
         }
 
         @Override

--- a/src/main/java/no/digipost/signature/client/direct/DirectJob.java
+++ b/src/main/java/no/digipost/signature/client/direct/DirectJob.java
@@ -110,15 +110,15 @@ public class DirectJob implements SignatureJob, WithExitUrls {
      * @see DirectJob#builder(String, DirectDocument, WithExitUrls, DirectSigner...)
      */
     public static Builder builder(String title, DirectDocument document, WithExitUrls hasExitUrls, List<DirectSigner> signers) {
-        return new Builder(title, signers, Collections.singletonList(document), hasExitUrls.getCompletionUrl(), hasExitUrls.getRejectionUrl(), hasExitUrls.getErrorUrl());
+        return builder(title, Collections.singletonList(document), hasExitUrls, signers);
+    }
+
+    public static Builder builder(String title, List<DirectDocument> documents, WithExitUrls hasExitUrls, DirectSigner... signers) {
+        return builder(title, documents, hasExitUrls, Arrays.asList(signers));
     }
 
     public static Builder builder(String title, List<DirectDocument> documents, WithExitUrls hasExitUrls, List<DirectSigner> signers) {
         return new Builder(title, signers, documents, hasExitUrls.getCompletionUrl(), hasExitUrls.getRejectionUrl(), hasExitUrls.getErrorUrl());
-    }
-
-    public static Builder builder(String title, List<DirectDocument> documents, WithExitUrls hasExitUrls, DirectSigner... signers) {
-        return new Builder(title, Arrays.asList(signers), documents, hasExitUrls.getCompletionUrl(), hasExitUrls.getRejectionUrl(), hasExitUrls.getErrorUrl());
     }
 
     public String getTitle() {

--- a/src/main/java/no/digipost/signature/client/direct/DirectJob.java
+++ b/src/main/java/no/digipost/signature/client/direct/DirectJob.java
@@ -117,6 +117,10 @@ public class DirectJob implements SignatureJob, WithExitUrls {
         return new Builder(title, signers, documents, hasExitUrls.getCompletionUrl(), hasExitUrls.getRejectionUrl(), hasExitUrls.getErrorUrl());
     }
 
+    public static Builder builder(String title, List<DirectDocument> documents, WithExitUrls hasExitUrls, DirectSigner... signers) {
+        return new Builder(title, Arrays.asList(signers), documents, hasExitUrls.getCompletionUrl(), hasExitUrls.getRejectionUrl(), hasExitUrls.getErrorUrl());
+    }
+
     public String getTitle() {
         return title;
     }

--- a/src/test/java/no/digipost/signature/client/asice/CreateASiCETest.java
+++ b/src/test/java/no/digipost/signature/client/asice/CreateASiCETest.java
@@ -56,19 +56,18 @@ public class CreateASiCETest {
 
     private static Path dumpFolder;
 
-    private static final DirectDocument DIRECT_DOCUMENT = DirectDocument.builder("Title", "file.txt", "hello".getBytes())
-            .message("Message")
+    private static final DirectDocument DIRECT_DOCUMENT = DirectDocument.builder("Document title", "file.txt", "hello".getBytes())
             .fileType(Document.FileType.TXT)
             .build();
 
-    private static final PortalDocument PORTAL_DOCUMENT = PortalDocument.builder("Title", "file.txt", "hello".getBytes())
+    private static final PortalDocument PORTAL_DOCUMENT = PortalDocument.builder("Document title", "file.txt", "hello".getBytes())
             .fileType(Document.FileType.TXT)
             .build();
 
 
     @Test
     public void create_direct_asice_and_write_to_disk() throws IOException {
-        DirectJob job = DirectJob.builder(DIRECT_DOCUMENT, singleExitUrl(URI.create("https://job.well.done.org")), DirectSigner.withPersonalIdentificationNumber("12345678910").build())
+        DirectJob job = DirectJob.builder("Job title", DIRECT_DOCUMENT, singleExitUrl(URI.create("https://job.well.done.org")), DirectSigner.withPersonalIdentificationNumber("12345678910").build())
                 .withReference("direct job")
                 .build();
 

--- a/src/test/java/no/digipost/signature/client/asice/manifest/CreateDirectManifestTest.java
+++ b/src/test/java/no/digipost/signature/client/asice/manifest/CreateDirectManifestTest.java
@@ -22,11 +22,11 @@ class CreateDirectManifestTest {
         CreateDirectManifest createManifest = new CreateDirectManifest();
 
         DirectDocument document = DirectDocument.builder("Title", "file.txt", "hello".getBytes())
-                .message("Message")
                 .fileType(Document.FileType.TXT)
                 .build();
 
         DirectJob job = DirectJob.builder(
+                    "Job title",
                     document,
                     ExitUrls.of(URI.create("http://localhost/signed"), URI.create("http://localhost/canceled"), URI.create("http://localhost/failed")),
                     DirectSigner.withPersonalIdentificationNumber("12345678910").build())

--- a/src/test/java/no/digipost/signature/client/docs/DirectClientUseCases.java
+++ b/src/test/java/no/digipost/signature/client/docs/DirectClientUseCases.java
@@ -32,7 +32,7 @@ class DirectClientUseCases {
         DirectClient client = new DirectClient(clientConfiguration);
 
         byte[] documentBytes = null; // Loaded document bytes
-        DirectDocument document = DirectDocument.builder("Subject", "document.pdf", documentBytes).build();
+        DirectDocument document = DirectDocument.builder("Document title", "document.pdf", documentBytes).build();
 
         ExitUrls exitUrls = ExitUrls.of(
                 URI.create("http://sender.org/onCompletion"),
@@ -41,7 +41,7 @@ class DirectClientUseCases {
         );
 
         DirectSigner signer = DirectSigner.withPersonalIdentificationNumber("12345678910").build();
-        DirectJob directJob = DirectJob.builder(document, exitUrls, signer).build();
+        DirectJob directJob = DirectJob.builder("Job title", document, exitUrls, signer).build();
 
         DirectJobResponse directJobResponse = client.create(directJob);
     }
@@ -102,7 +102,7 @@ class DirectClientUseCases {
     static void create_job_and_status_by_polling() {
         DirectClient client = null; // As initialized earlier
 
-        DirectJob directJob = DirectJob.builder(document, exitUrls, signer)
+        DirectJob directJob = DirectJob.builder("Job title", document, exitUrls, signer)
                 .retrieveStatusBy(StatusRetrievalMethod.POLLING)
                 .build();
 
@@ -148,7 +148,7 @@ class DirectClientUseCases {
         DirectClient client = null; // As initialized earlier
         Sender sender = new Sender("000000000", PollingQueue.of("CustomPollingQueue"));
 
-        DirectJob directJob = DirectJob.builder(document, exitUrls, signer)
+        DirectJob directJob = DirectJob.builder("Job title", document, exitUrls, signer)
                 .retrieveStatusBy(StatusRetrievalMethod.POLLING).withSender(sender)
                 .build();
 


### PR DESCRIPTION
### 💰 Funksjonell beskrivelse av endringen

Legger til støtte for opprettelse av flere dokumenter for direktejobber.


### 🤷‍♀️ Anbefalt fremgangsmåte

Hele smæla på en gang? Det er omtrent de samme endringene som ble gjort for portal i https://github.com/digipost/signature-api-client-java/pull/174



### ⚙️ Avhengigheter 

https://github.com/digipost/signature-api-specification/pull/173
