### PR TITLE
5.0 final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <project.previousVersion>set_with_-Dproject.previousVersion=X.Y</project.previousVersion>
         <signature.api.version>2.7</signature.api.version>
         <slf4j.version>1.7.29</slf4j.version>
     </properties>
@@ -242,8 +243,15 @@
                 <plugin>
                     <groupId>com.github.siom79.japicmp</groupId>
                     <artifactId>japicmp-maven-plugin</artifactId>
-                    <version>0.14.2</version>
+                    <version>0.15.2</version>
                     <configuration>
+                        <oldVersion>
+                            <dependency>
+                                <groupId>${project.groupId}</groupId>
+                                <artifactId>${project.artifactId}</artifactId>
+                                <version>${project.previousVersion}</version>
+                            </dependency>
+                        </oldVersion>
                         <newVersion>
                             <file>
                                 <path>${project.build.directory}/${project.build.finalName}.${project.packaging}</path>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.previousVersion>set_with_-Dproject.previousVersion=X.Y</project.previousVersion>
         <signature.api.version>2.7</signature.api.version>
-        <slf4j.version>1.7.29</slf4j.version>
+        <slf4j.version>1.7.30</slf4j.version>
     </properties>
 
     <dependencyManagement>
@@ -26,21 +26,21 @@
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-framework-bom</artifactId>
-                <version>5.2.1.RELEASE</version>
+                <version>5.3.3</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.jersey</groupId>
                 <artifactId>jersey-bom</artifactId>
-                <version>2.29.1</version>
+                <version>2.33</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
-                <version>5.6.0-M1</version>
+                <version>5.7.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.10</version>
+            <version>4.5.13</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>
@@ -73,7 +73,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
-            <version>4.4.12</version>
+            <version>4.4.14</version>
         </dependency>
         <dependency>
             <groupId>jakarta.annotation</groupId>
@@ -106,13 +106,13 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.6</version>
+            <version>2.8.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.13</version>
+            <version>1.15</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
@@ -125,12 +125,12 @@
         <dependency>
             <groupId>org.springframework.ws</groupId>
             <artifactId>spring-xml</artifactId>
-            <version>3.0.8.RELEASE</version>
+            <version>3.0.10.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.9</version>
+            <version>3.11</version>
         </dependency>
 
         <dependency>
@@ -170,7 +170,7 @@
         <dependency>
             <groupId>nl.jqno.equalsverifier</groupId>
             <artifactId>equalsverifier</artifactId>
-            <version>3.1.10</version>
+            <version>3.5.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -194,7 +194,7 @@
         <dependency>
             <groupId>no.digipost</groupId>
             <artifactId>digg</artifactId>
-            <version>0.22</version>
+            <version>0.25</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -174,9 +174,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>co.unruly</groupId>
+            <groupId>uk.co.probablyfine</groupId>
             <artifactId>java-8-matchers</artifactId>
-            <version>1.6</version>
+            <version>1.9</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/src/main/java/no/digipost/signature/client/asice/CreateASiCE.java
+++ b/src/main/java/no/digipost/signature/client/asice/CreateASiCE.java
@@ -8,6 +8,7 @@ import no.digipost.signature.client.asice.signature.Signature;
 import no.digipost.signature.client.core.Sender;
 import no.digipost.signature.client.core.SignatureJob;
 import no.digipost.signature.client.core.exceptions.RuntimeIOException;
+import no.digipost.signature.client.core.internal.ActualSender;
 import no.digipost.signature.client.security.KeyStoreConfig;
 
 import java.io.ByteArrayInputStream;
@@ -15,8 +16,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-
-import static no.digipost.signature.client.core.exceptions.SenderNotSpecifiedException.SENDER_NOT_SPECIFIED;
 
 public class CreateASiCE<JOB extends SignatureJob> {
 
@@ -37,10 +36,7 @@ public class CreateASiCE<JOB extends SignatureJob> {
     }
 
     public DocumentBundle createASiCE(JOB job) {
-        Sender sender = job.getSender()
-                .orElse(globalSender
-                .orElseThrow(SENDER_NOT_SPECIFIED));
-
+        Sender sender = ActualSender.getActualSender(job.getSender(), globalSender);
         Manifest manifest = manifestCreator.createManifest(job, sender);
 
         List<ASiCEAttachable> files = new ArrayList<>();

--- a/src/main/java/no/digipost/signature/client/core/internal/ActualSender.java
+++ b/src/main/java/no/digipost/signature/client/core/internal/ActualSender.java
@@ -6,8 +6,11 @@ import java.util.Optional;
 
 import static no.digipost.signature.client.core.exceptions.SenderNotSpecifiedException.SENDER_NOT_SPECIFIED;
 
-public class ActualSender {
+public final class ActualSender {
     public static Sender getActualSender(Optional<Sender> messageSpecificSender, Optional<Sender> globalSender) {
-        return messageSpecificSender.orElse(globalSender.orElseThrow(SENDER_NOT_SPECIFIED));
+        return messageSpecificSender.orElseGet(() -> globalSender.orElseThrow(SENDER_NOT_SPECIFIED));
+    }
+
+    private ActualSender() {
     }
 }

--- a/src/test/java/no/digipost/signature/client/asice/manifest/CreateDirectManifestTest.java
+++ b/src/test/java/no/digipost/signature/client/asice/manifest/CreateDirectManifestTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test;
 
 import java.net.URI;
 
-import static co.unruly.matchers.Java8Matchers.where;
+import static uk.co.probablyfine.matchers.Java8Matchers.where;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 

--- a/src/test/java/no/digipost/signature/client/asice/manifest/CreatePortalManifestTest.java
+++ b/src/test/java/no/digipost/signature/client/asice/manifest/CreatePortalManifestTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test;
 import java.time.Clock;
 import java.util.Collections;
 
-import static co.unruly.matchers.Java8Matchers.where;
+import static uk.co.probablyfine.matchers.Java8Matchers.where;
 import static java.util.concurrent.TimeUnit.DAYS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;

--- a/src/test/java/no/digipost/signature/client/asice/signature/CreateSignatureTest.java
+++ b/src/test/java/no/digipost/signature/client/asice/signature/CreateSignatureTest.java
@@ -26,7 +26,7 @@ import java.time.ZonedDateTime;
 import java.util.Base64;
 import java.util.List;
 
-import static co.unruly.matchers.Java8Matchers.where;
+import static uk.co.probablyfine.matchers.Java8Matchers.where;
 import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;

--- a/src/test/java/no/digipost/signature/client/core/internal/ActualSenderTest.java
+++ b/src/test/java/no/digipost/signature/client/core/internal/ActualSenderTest.java
@@ -1,0 +1,35 @@
+package no.digipost.signature.client.core.internal;
+
+import no.digipost.signature.client.core.Sender;
+import no.digipost.signature.client.core.exceptions.SenderNotSpecifiedException;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ActualSenderTest {
+
+    @Test
+    void throwsIfNoSenderIsAvailable() {
+        assertThrows(SenderNotSpecifiedException.class, () -> ActualSender.getActualSender(Optional.empty(), Optional.empty()));
+    }
+
+    @Test
+    void prioritizesSenderOnJob() {
+        Sender senderOnJob = new Sender("123456789");
+        Sender actualSender = ActualSender.getActualSender(Optional.of(senderOnJob), Optional.empty());
+        assertThat(actualSender, sameInstance(senderOnJob));
+    }
+
+    @Test
+    void fallsBackToGlobalSender() {
+        Sender globalSender = new Sender("123456789");
+        Sender actualSender = ActualSender.getActualSender(Optional.empty(), Optional.of(globalSender));
+        assertThat(actualSender, sameInstance(globalSender));
+    }
+
+
+}

--- a/src/test/java/no/digipost/signature/client/direct/DirectJobResponseTest.java
+++ b/src/test/java/no/digipost/signature/client/direct/DirectJobResponseTest.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Test;
 
 import java.net.URI;
 
-import static co.unruly.matchers.Java8Matchers.where;
+import static uk.co.probablyfine.matchers.Java8Matchers.where;
 import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;

--- a/src/test/java/no/digipost/signature/client/direct/SignerStatusTest.java
+++ b/src/test/java/no/digipost/signature/client/direct/SignerStatusTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 import java.lang.reflect.Field;
 import java.util.stream.Stream;
 
-import static co.unruly.matchers.Java8Matchers.where;
+import static uk.co.probablyfine.matchers.Java8Matchers.where;
 import static java.lang.reflect.Modifier.isPublic;
 import static java.lang.reflect.Modifier.isStatic;
 import static no.digipost.DiggExceptions.mayThrow;

--- a/src/test/java/no/digipost/signature/client/portal/PortalSignerTest.java
+++ b/src/test/java/no/digipost/signature/client/portal/PortalSignerTest.java
@@ -2,10 +2,10 @@ package no.digipost.signature.client.portal;
 
 import org.junit.jupiter.api.Test;
 
-import static co.unruly.matchers.Java8Matchers.where;
-import static co.unruly.matchers.Java8Matchers.whereNot;
-import static co.unruly.matchers.OptionalMatchers.contains;
-import static co.unruly.matchers.OptionalMatchers.empty;
+import static uk.co.probablyfine.matchers.Java8Matchers.where;
+import static uk.co.probablyfine.matchers.Java8Matchers.whereNot;
+import static uk.co.probablyfine.matchers.OptionalMatchers.contains;
+import static uk.co.probablyfine.matchers.OptionalMatchers.empty;
 import static no.digipost.signature.client.portal.PortalSigner.identifiedByEmail;
 import static no.digipost.signature.client.portal.PortalSigner.identifiedByEmailAndMobileNumber;
 import static no.digipost.signature.client.portal.PortalSigner.identifiedByMobileNumber;

--- a/src/test/java/no/digipost/signature/client/portal/SignatureStatusTest.java
+++ b/src/test/java/no/digipost/signature/client/portal/SignatureStatusTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 import java.lang.reflect.Field;
 import java.util.stream.Stream;
 
-import static co.unruly.matchers.Java8Matchers.where;
+import static uk.co.probablyfine.matchers.Java8Matchers.where;
 import static java.lang.reflect.Modifier.isPublic;
 import static java.lang.reflect.Modifier.isStatic;
 import static no.digipost.DiggExceptions.mayThrow;

--- a/src/test/java/no/digipost/signature/client/portal/SignerTest.java
+++ b/src/test/java/no/digipost/signature/client/portal/SignerTest.java
@@ -6,8 +6,8 @@ import no.digipost.signature.api.xml.XMLSms;
 import no.digipost.signature.client.portal.Signature.Signer;
 import org.junit.jupiter.api.Test;
 
-import static co.unruly.matchers.Java8Matchers.where;
-import static co.unruly.matchers.Java8Matchers.whereNot;
+import static uk.co.probablyfine.matchers.Java8Matchers.where;
+import static uk.co.probablyfine.matchers.Java8Matchers.whereNot;
 import static no.digipost.signature.client.portal.SignerIdentifier.identifiedByEmailAddress;
 import static no.digipost.signature.client.portal.SignerIdentifier.identifiedByEmailAddressAndMobileNumber;
 import static no.digipost.signature.client.portal.SignerIdentifier.identifiedByMobileNumber;

--- a/src/test/java/no/digipost/signature/client/security/KeyStoreConfigTest.java
+++ b/src/test/java/no/digipost/signature/client/security/KeyStoreConfigTest.java
@@ -4,7 +4,7 @@ import no.digipost.signature.client.TestCertificates;
 import no.digipost.signature.client.core.exceptions.KeyException;
 import org.junit.jupiter.api.Test;
 
-import static co.unruly.matchers.Java8Matchers.where;
+import static uk.co.probablyfine.matchers.Java8Matchers.where;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;


### PR DESCRIPTION
5.0 release just to finalize all the release candidates for introducing this: https://github.com/digipost/signature-api-client-java/releases/tag/5.0

Binaries are already released: https://search.maven.org/artifact/no.digipost.signature/signature-api-client-java/5.0/jar

And a 5.0.1 is pending, containing fix for #169, and will be pushed to central repository when we get through with the staging at Sonatype.
