### PR TITLE
Autogenerate ASiCE filenames

### DIFF
--- a/src/main/java/no/digipost/signature/client/asice/ASiCEAttachable.java
+++ b/src/main/java/no/digipost/signature/client/asice/ASiCEAttachable.java
@@ -5,12 +5,37 @@ import no.digipost.signature.client.asice.signature.SignableFileReference;
 import static org.apache.commons.codec.digest.DigestUtils.sha256;
 
 public interface ASiCEAttachable extends SignableFileReference {
+
+    interface Type {
+        static final Type XML = new Type() {
+            @Override
+            public String getMediaType() {
+                return "application/xml";
+            }
+
+            @Override
+            public String getFileExtension() {
+                return "xml";
+            }
+        };
+
+        String getMediaType();
+
+        String getFileExtension();
+    }
+
+
     @Override
     String getFileName();
 
     byte[] getBytes();
 
-    String getMimeType();
+    ASiCEAttachable.Type getType();
+
+    @Override
+    default String getMimeType() {
+        return getType().getMediaType();
+    }
 
     @Override
     default byte[] getSha256() {

--- a/src/main/java/no/digipost/signature/client/asice/ASiCEAttachable.java
+++ b/src/main/java/no/digipost/signature/client/asice/ASiCEAttachable.java
@@ -6,36 +6,15 @@ import static org.apache.commons.codec.digest.DigestUtils.sha256;
 
 public interface ASiCEAttachable extends SignableFileReference {
 
-    interface Type {
-        static final Type XML = new Type() {
-            @Override
-            public String getMediaType() {
-                return "application/xml";
-            }
-
-            @Override
-            public String getFileExtension() {
-                return "xml";
-            }
-        };
-
-        String getMediaType();
-
-        String getFileExtension();
-    }
-
+    public static final String XML_MEDIATYPE = "application/xml";
 
     @Override
     String getFileName();
 
     byte[] getBytes();
 
-    ASiCEAttachable.Type getType();
-
     @Override
-    default String getMimeType() {
-        return getType().getMediaType();
-    }
+    String getMediaType();
 
     @Override
     default byte[] getSha256() {

--- a/src/main/java/no/digipost/signature/client/asice/manifest/CreateDirectManifest.java
+++ b/src/main/java/no/digipost/signature/client/asice/manifest/CreateDirectManifest.java
@@ -45,7 +45,7 @@ public class CreateDirectManifest extends ManifestCreator<DirectJob> {
                         .map(document -> new XMLDirectDocument()
                                     .withTitle(document.getTitle())
                                     .withHref(XMLHref.of(document.getFileName()))
-                                    .withMime(document.getMimeType()))
+                                    .withMime(document.getMediaType()))
                         .collect(toList()))
                 .withIdentifierInSignedDocuments(job.getIdentifierInSignedDocuments().map(IdentifierInSignedDocuments::getXmlEnumValue).orElse(null));
     }

--- a/src/main/java/no/digipost/signature/client/asice/manifest/CreatePortalManifest.java
+++ b/src/main/java/no/digipost/signature/client/asice/manifest/CreatePortalManifest.java
@@ -64,7 +64,7 @@ public class CreatePortalManifest extends ManifestCreator<PortalJob> {
                         .map(document -> new XMLPortalDocument()
                                     .withTitle(document.getTitle())
                                     .withHref(XMLHref.of(document.getFileName()))
-                                    .withMime(document.getMimeType()))
+                                    .withMime(document.getMediaType()))
                         .collect(toList()))
                 .withAvailability(new XMLAvailability()
                         .withActivationTime(activationTime)

--- a/src/main/java/no/digipost/signature/client/asice/manifest/Manifest.java
+++ b/src/main/java/no/digipost/signature/client/asice/manifest/Manifest.java
@@ -21,7 +21,8 @@ public class Manifest implements ASiCEAttachable {
     }
 
     @Override
-    public String getMimeType() {
-        return "application/xml";
+    public Type getType() {
+        return Type.XML;
     }
+
 }

--- a/src/main/java/no/digipost/signature/client/asice/manifest/Manifest.java
+++ b/src/main/java/no/digipost/signature/client/asice/manifest/Manifest.java
@@ -21,8 +21,8 @@ public class Manifest implements ASiCEAttachable {
     }
 
     @Override
-    public Type getType() {
-        return Type.XML;
+    public String getMediaType() {
+        return XML_MEDIATYPE;
     }
 
 }

--- a/src/main/java/no/digipost/signature/client/asice/signature/CreateSignature.java
+++ b/src/main/java/no/digipost/signature/client/asice/signature/CreateSignature.java
@@ -169,8 +169,9 @@ public class CreateSignature {
         for (int i = 0; i < files.size(); i++) {
             try {
                 String signatureElementId = "ID_" + i;
-                String uri = URLEncoder.encode(files.get(i).getFileName(), "UTF-8");
-                Reference reference = xmlSignatureFactory.newReference(uri, sha256DigestMethod, null, null, signatureElementId, files.get(i).getSha256());
+                SignableFileReference file = files.get(i);
+                String uri = URLEncoder.encode(file.getFileName(), "UTF-8");
+                Reference reference = xmlSignatureFactory.newReference(uri, sha256DigestMethod, null, null, signatureElementId, file.getSha256());
                 result.add(reference);
             } catch(UnsupportedEncodingException e) {
                 throw new RuntimeException(e);

--- a/src/main/java/no/digipost/signature/client/asice/signature/CreateXAdESArtifacts.java
+++ b/src/main/java/no/digipost/signature/client/asice/signature/CreateXAdESArtifacts.java
@@ -60,7 +60,7 @@ class CreateXAdESArtifacts {
         List<DataObjectFormat> result = new ArrayList<>();
         for (int i = 0; i < files.size(); i++) {
             String signatureElementIdReference = format("#ID_%s", i);
-            result.add(new DataObjectFormat(null, null, files.get(i).getMimeType(), null, signatureElementIdReference));
+            result.add(new DataObjectFormat(null, null, files.get(i).getMediaType(), null, signatureElementIdReference));
         }
         return result;
     }

--- a/src/main/java/no/digipost/signature/client/asice/signature/SignableFileReference.java
+++ b/src/main/java/no/digipost/signature/client/asice/signature/SignableFileReference.java
@@ -6,6 +6,6 @@ public interface SignableFileReference {
 
     byte[] getSha256();
 
-    String getMimeType();
+    String getMediaType();
 
 }

--- a/src/main/java/no/digipost/signature/client/asice/signature/Signature.java
+++ b/src/main/java/no/digipost/signature/client/asice/signature/Signature.java
@@ -21,8 +21,8 @@ public class Signature implements ASiCEAttachable {
     }
 
     @Override
-    public String getMimeType() {
-        return "application/xml";
+    public Type getType() {
+        return Type.XML;
     }
 
 }

--- a/src/main/java/no/digipost/signature/client/asice/signature/Signature.java
+++ b/src/main/java/no/digipost/signature/client/asice/signature/Signature.java
@@ -21,8 +21,8 @@ public class Signature implements ASiCEAttachable {
     }
 
     @Override
-    public Type getType() {
-        return Type.XML;
+    public String getMediaType() {
+        return XML_MEDIATYPE;
     }
 
 }

--- a/src/main/java/no/digipost/signature/client/core/Document.java
+++ b/src/main/java/no/digipost/signature/client/core/Document.java
@@ -5,15 +5,19 @@ import no.digipost.signature.client.asice.ASiCEAttachable;
 public abstract class Document implements ASiCEAttachable {
 
     private final String title;
+    private final DocumentType documentType;
     private final String fileName;
     private final byte[] document;
-    private final FileType fileType;
 
-    protected Document(String title, String fileName, FileType fileType, byte[] document) {
+    protected Document(String title, DocumentType documentType, String fileName, byte[] document) {
         this.title = title;
+        this.documentType = documentType;
         this.fileName = fileName;
-        this.fileType = fileType;
         this.document = document;
+    }
+
+    public String getTitle() {
+        return title;
     }
 
     @Override
@@ -22,27 +26,13 @@ public abstract class Document implements ASiCEAttachable {
     }
 
     @Override
+    public Type getType() {
+        return documentType;
+    }
+
+    @Override
     public byte[] getBytes() {
         return document;
     }
 
-    @Override
-    public String getMimeType() {
-        return fileType.mimeType;
-    }
-
-    public String getTitle() {
-        return title;
-    }
-
-    public enum FileType {
-        PDF("application/pdf"),
-        TXT("text/plain");
-
-        public final String mimeType;
-
-        FileType(final String mimeType) {
-            this.mimeType = mimeType;
-        }
-    }
 }

--- a/src/main/java/no/digipost/signature/client/core/Document.java
+++ b/src/main/java/no/digipost/signature/client/core/Document.java
@@ -2,14 +2,14 @@ package no.digipost.signature.client.core;
 
 import no.digipost.signature.client.asice.ASiCEAttachable;
 
-public abstract class Document implements ASiCEAttachable {
+public class Document implements ASiCEAttachable {
 
     private final String title;
     private final DocumentType documentType;
     private final String fileName;
     private final byte[] document;
 
-    protected Document(String title, DocumentType documentType, String fileName, byte[] document) {
+    public Document(String title, DocumentType documentType, String fileName, byte[] document) {
         this.title = title;
         this.documentType = documentType;
         this.fileName = fileName;

--- a/src/main/java/no/digipost/signature/client/core/Document.java
+++ b/src/main/java/no/digipost/signature/client/core/Document.java
@@ -5,13 +5,13 @@ import no.digipost.signature.client.asice.ASiCEAttachable;
 public class Document implements ASiCEAttachable {
 
     private final String title;
-    private final DocumentType documentType;
+    private final String mediaType;
     private final String fileName;
     private final byte[] document;
 
-    public Document(String title, DocumentType documentType, String fileName, byte[] document) {
+    public Document(String title, String mediaType, String fileName, byte[] document) {
         this.title = title;
-        this.documentType = documentType;
+        this.mediaType = mediaType;
         this.fileName = fileName;
         this.document = document;
     }
@@ -26,8 +26,8 @@ public class Document implements ASiCEAttachable {
     }
 
     @Override
-    public Type getType() {
-        return documentType;
+    public String getMediaType() {
+        return mediaType;
     }
 
     @Override

--- a/src/main/java/no/digipost/signature/client/core/DocumentType.java
+++ b/src/main/java/no/digipost/signature/client/core/DocumentType.java
@@ -1,8 +1,6 @@
 package no.digipost.signature.client.core;
 
-import no.digipost.signature.client.asice.ASiCEAttachable;
-
-public enum DocumentType implements ASiCEAttachable.Type {
+public enum DocumentType {
 
     PDF("application/pdf", "pdf"),
     TXT("text/plain", "txt");
@@ -15,12 +13,10 @@ public enum DocumentType implements ASiCEAttachable.Type {
         this.fileExtension = fileExtension;
     }
 
-    @Override
     public String getMediaType() {
         return mediaType;
     }
 
-    @Override
     public String getFileExtension() {
         return fileExtension;
     }

--- a/src/main/java/no/digipost/signature/client/core/DocumentType.java
+++ b/src/main/java/no/digipost/signature/client/core/DocumentType.java
@@ -1,0 +1,28 @@
+package no.digipost.signature.client.core;
+
+import no.digipost.signature.client.asice.ASiCEAttachable;
+
+public enum DocumentType implements ASiCEAttachable.Type {
+
+    PDF("application/pdf", "pdf"),
+    TXT("text/plain", "txt");
+
+    private final String mediaType;
+    private final String fileExtension;
+
+    DocumentType(String mediaType, String fileExtension) {
+        this.mediaType = mediaType;
+        this.fileExtension = fileExtension;
+    }
+
+    @Override
+    public String getMediaType() {
+        return mediaType;
+    }
+
+    @Override
+    public String getFileExtension() {
+        return fileExtension;
+    }
+
+}

--- a/src/main/java/no/digipost/signature/client/core/SignatureJob.java
+++ b/src/main/java/no/digipost/signature/client/core/SignatureJob.java
@@ -5,7 +5,7 @@ import java.util.Optional;
 
 public interface SignatureJob {
 
-    List<? extends Document> getDocuments();
+    List<Document> getDocuments();
 
     Optional<Sender> getSender();
 

--- a/src/main/java/no/digipost/signature/client/core/internal/FileName.java
+++ b/src/main/java/no/digipost/signature/client/core/internal/FileName.java
@@ -1,0 +1,89 @@
+package no.digipost.signature.client.core.internal;
+
+import java.text.Normalizer;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.regex.Pattern;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static java.text.Normalizer.Form.NFD;
+import static java.util.Arrays.binarySearch;
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.IntStream.rangeClosed;
+
+public final class FileName {
+
+    private static final Map<Pattern, String> knownReplacements; static {
+        knownReplacements = new LinkedHashMap<>();
+        knownReplacements.put(Pattern.compile("[\\s:;&%\\$\\*\\?\\+=@,\\(\\)\\[\\]\\{\\}#!\"“”\\^`´<>]+"), "_"); //various punctuation
+        knownReplacements.put(Pattern.compile("[æÆ]"), "ae");
+        knownReplacements.put(Pattern.compile("[øØ]"), "oe");
+        knownReplacements.put(Pattern.compile("[åÅ]"), "aa");
+    }
+
+    private static final char[] allowedChars = Stream.of(
+            rangeClosed('0', '9'),
+            rangeClosed('a', 'z'),
+            IntStream.of('-', '_', '.'))
+        .flatMapToInt(identity())
+        .sorted()
+        .mapToObj(c -> String.valueOf((char) c))
+        .collect(joining())
+        .toCharArray();
+
+
+    public static String reduceToFileNameSafeChars(String text) {
+        if (text == null || text.isEmpty()) {
+            throw new IllegalArgumentException(text);
+        }
+        String knownReplacements = text;
+        for (Entry<Pattern, String> replacement : FileName.knownReplacements.entrySet()) {
+            knownReplacements = replacement.getKey().matcher(knownReplacements).replaceAll(replacement.getValue());
+        }
+        String accentsRemoved = removeAccents(knownReplacements);
+        return reduceToAlphabet(accentsRemoved.toLowerCase(), allowedChars);
+    }
+
+
+    /**
+     * Reduce a text to only contain characters of a given alphabet
+     * using the following algorithm:
+     * <ul>
+     *   <li>characters already part of the alphabet are kept as-is</li>
+     *   <li>characters not part of the alphabet is replaced with a
+     *       character from the alphabet in a non-defined, but repeatable manner.</li>
+     * </ul>
+     *
+     * @param text the source text
+     * @param alphabet the allowed characters in the resulting String
+     * @return the resulting string
+     */
+    private static String reduceToAlphabet(String text, char[] alphabet) {
+        StringBuilder reducedToAllowedChars = new StringBuilder(text.length());
+        for (int c : text.toCharArray()) {
+            if (binarySearch(allowedChars, (char) c) >= 0) {
+                reducedToAllowedChars.append((char) c);
+            } else {
+                reducedToAllowedChars.append(allowedChars[c % allowedChars.length]);
+            }
+        }
+        return reducedToAllowedChars.toString();
+    }
+
+
+    private static final Pattern UNICODE_ACCENT = Pattern.compile("\\p{M}");
+
+    /**
+     * Replaces accented characters (è, ü, etc) with their base glyphs (e, u, etc).
+     * @see https://stackoverflow.com/questions/3322152/is-there-a-way-to-get-rid-of-accents-and-convert-a-whole-string-to-regular-lette
+     */
+    private static String removeAccents(String text) {
+        return UNICODE_ACCENT.matcher(Normalizer.normalize(text, NFD)).replaceAll("");
+    }
+
+    private FileName() {
+    }
+}

--- a/src/main/java/no/digipost/signature/client/direct/DirectDocument.java
+++ b/src/main/java/no/digipost/signature/client/direct/DirectDocument.java
@@ -1,39 +1,51 @@
 package no.digipost.signature.client.direct;
 
 import no.digipost.signature.client.core.Document;
+import no.digipost.signature.client.core.DocumentType;
 
-import static no.digipost.signature.client.core.Document.FileType.PDF;
+import static java.util.Objects.requireNonNull;
+import static no.digipost.signature.client.core.DocumentType.PDF;
+import static no.digipost.signature.client.core.internal.FileName.reduceToFileNameSafeChars;
+
 
 public class DirectDocument extends Document {
 
-    private DirectDocument(String title, String fileName, FileType fileType, byte[] document) {
-        super(title, fileName, fileType, document);
+    public static Builder builder(String title, byte[] document) {
+        return new Builder(title, document);
     }
 
-    public static Builder builder(String title, String fileName, byte[] document) {
-        return new Builder(title, fileName, document);
+
+    private DirectDocument(String title, DocumentType documentType, String fileName, byte[] document) {
+        super(title, documentType, fileName, document);
     }
 
     public static class Builder {
 
         private String title;
+        private DocumentType documentType = PDF;
         private String fileName;
         private byte[] document;
-        private FileType fileType = PDF;
 
-        public Builder(String title, String fileName, byte[] document) {
-            this.title = title;
-            this.fileName = fileName;
-            this.document = document;
+        public Builder(String title, byte[] document) {
+            this.title = requireNonNull(title, "title");
+            this.document = requireNonNull(document, "document bytes");
         }
 
-        public Builder fileType(FileType fileType) {
-            this.fileType = fileType;
+        public Builder type(DocumentType documentType) {
+            this.documentType = requireNonNull(documentType, "document type");
+            return this;
+        }
+
+        public Builder fileName(String fileName) {
+            this.fileName = fileName;
             return this;
         }
 
         public DirectDocument build() {
-            return new DirectDocument(title, fileName, fileType, document);
+            return new DirectDocument(
+                    title, documentType,
+                    fileName == null ? reduceToFileNameSafeChars(title) + "." + documentType.getFileExtension() : fileName,
+                    document);
         }
     }
 }

--- a/src/main/java/no/digipost/signature/client/direct/DirectDocument.java
+++ b/src/main/java/no/digipost/signature/client/direct/DirectDocument.java
@@ -1,29 +1,33 @@
 package no.digipost.signature.client.direct;
 
-import no.digipost.signature.client.core.Document;
 import no.digipost.signature.client.core.DocumentType;
 
 import static java.util.Objects.requireNonNull;
 import static no.digipost.signature.client.core.DocumentType.PDF;
-import static no.digipost.signature.client.core.internal.FileName.reduceToFileNameSafeChars;
 
 
-public class DirectDocument extends Document {
+public class DirectDocument {
 
     public static Builder builder(String title, byte[] document) {
         return new Builder(title, document);
     }
 
 
-    private DirectDocument(String title, DocumentType documentType, String fileName, byte[] document) {
-        super(title, documentType, fileName, document);
+    public final String title;
+    public final DocumentType type;
+    public final byte[] document;
+
+    private DirectDocument(String title, DocumentType type, byte[] document) {
+        this.title = title;
+        this.type = type;
+        this.document = document;
     }
+
 
     public static class Builder {
 
         private String title;
         private DocumentType documentType = PDF;
-        private String fileName;
         private byte[] document;
 
         public Builder(String title, byte[] document) {
@@ -36,16 +40,8 @@ public class DirectDocument extends Document {
             return this;
         }
 
-        public Builder fileName(String fileName) {
-            this.fileName = fileName;
-            return this;
-        }
-
         public DirectDocument build() {
-            return new DirectDocument(
-                    title, documentType,
-                    fileName == null ? reduceToFileNameSafeChars(title) + "." + documentType.getFileExtension() : fileName,
-                    document);
+            return new DirectDocument(title, documentType, document);
         }
     }
 }

--- a/src/main/java/no/digipost/signature/client/direct/DirectJob.java
+++ b/src/main/java/no/digipost/signature/client/direct/DirectJob.java
@@ -57,7 +57,7 @@ public class DirectJob implements SignatureJob, WithExitUrls {
         List<Document> documents = new ArrayList<>();
         for (int i = 0; i < this.documents.size(); i++) {
             DirectDocument doc = this.documents.get(i);
-            documents.add(new Document(doc.title, doc.type,
+            documents.add(new Document(doc.title, doc.type.getMediaType(),
                     format("%04d", i) + "_" + reduceToFileNameSafeChars(doc.title) + "." + doc.type.getFileExtension(),
                     doc.document));
         }

--- a/src/main/java/no/digipost/signature/client/direct/DirectJob.java
+++ b/src/main/java/no/digipost/signature/client/direct/DirectJob.java
@@ -1,6 +1,7 @@
 package no.digipost.signature.client.direct;
 
 import no.digipost.signature.client.core.AuthenticationLevel;
+import no.digipost.signature.client.core.Document;
 import no.digipost.signature.client.core.IdentifierInSignedDocuments;
 import no.digipost.signature.client.core.Sender;
 import no.digipost.signature.client.core.SignatureJob;
@@ -12,8 +13,10 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import static java.lang.String.format;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.unmodifiableList;
+import static no.digipost.signature.client.core.internal.FileName.reduceToFileNameSafeChars;
 
 
 /**
@@ -50,7 +53,14 @@ public class DirectJob implements SignatureJob, WithExitUrls {
     }
 
     @Override
-    public List<DirectDocument> getDocuments() {
+    public List<Document> getDocuments() {
+        List<Document> documents = new ArrayList<>();
+        for (int i = 0; i < this.documents.size(); i++) {
+            DirectDocument doc = this.documents.get(i);
+            documents.add(new Document(doc.title, doc.type,
+                    format("%04d", i) + "_" + reduceToFileNameSafeChars(doc.title) + "." + doc.type.getFileExtension(),
+                    doc.document));
+        }
         return documents;
     }
 

--- a/src/main/java/no/digipost/signature/client/portal/PortalDocument.java
+++ b/src/main/java/no/digipost/signature/client/portal/PortalDocument.java
@@ -1,29 +1,33 @@
 package no.digipost.signature.client.portal;
 
-import no.digipost.signature.client.core.Document;
 import no.digipost.signature.client.core.DocumentType;
 
 import static java.util.Objects.requireNonNull;
 import static no.digipost.signature.client.core.DocumentType.PDF;
-import static no.digipost.signature.client.core.internal.FileName.reduceToFileNameSafeChars;
 
 
-public class PortalDocument extends Document {
+public class PortalDocument {
 
     public static Builder builder(String title, byte[] document) {
         return new Builder(title, document);
     }
 
 
-    private PortalDocument(String title, DocumentType documentType, String fileName, byte[] document) {
-        super(title, documentType, fileName, document);
+    public final String title;
+    public final DocumentType type;
+    public final byte[] document;
+
+    private PortalDocument(String title, DocumentType type, byte[] document) {
+        this.title = title;
+        this.type = type;
+        this.document = document;
     }
+
 
     public static class Builder {
 
         private String title;
         private DocumentType documentType = PDF;
-        private String fileName;
         private byte[] document;
 
         public Builder(String title, byte[] document) {
@@ -36,16 +40,8 @@ public class PortalDocument extends Document {
             return this;
         }
 
-        public Builder fileName(String fileName) {
-            this.fileName = fileName;
-            return this;
-        }
-
         public PortalDocument build() {
-            return new PortalDocument(
-                    title, documentType,
-                    fileName == null ? reduceToFileNameSafeChars(title) + "." + documentType.getFileExtension(): fileName,
-                    document);
+            return new PortalDocument(title, documentType, document);
         }
     }
 }

--- a/src/main/java/no/digipost/signature/client/portal/PortalDocument.java
+++ b/src/main/java/no/digipost/signature/client/portal/PortalDocument.java
@@ -1,39 +1,51 @@
 package no.digipost.signature.client.portal;
 
 import no.digipost.signature.client.core.Document;
+import no.digipost.signature.client.core.DocumentType;
 
-import static no.digipost.signature.client.core.Document.FileType.PDF;
+import static java.util.Objects.requireNonNull;
+import static no.digipost.signature.client.core.DocumentType.PDF;
+import static no.digipost.signature.client.core.internal.FileName.reduceToFileNameSafeChars;
+
 
 public class PortalDocument extends Document {
 
-    private PortalDocument(String title, String fileName, FileType fileType, byte[] document) {
-        super(title, fileName, fileType, document);
+    public static Builder builder(String title, byte[] document) {
+        return new Builder(title, document);
     }
 
-    public static Builder builder(String title, String fileName, byte[] document) {
-        return new Builder(title, fileName, document);
+
+    private PortalDocument(String title, DocumentType documentType, String fileName, byte[] document) {
+        super(title, documentType, fileName, document);
     }
 
     public static class Builder {
 
         private String title;
+        private DocumentType documentType = PDF;
         private String fileName;
         private byte[] document;
-        private FileType fileType = PDF;
 
-        public Builder(String title, String fileName, byte[] document) {
-            this.title = title;
-            this.fileName = fileName;
-            this.document = document;
+        public Builder(String title, byte[] document) {
+            this.title = requireNonNull(title, "title");
+            this.document = requireNonNull(document, "document bytes");
         }
 
-        public Builder fileType(FileType fileType) {
-            this.fileType = fileType;
+        public Builder type(DocumentType documentType) {
+            this.documentType = requireNonNull(documentType, "document type");
+            return this;
+        }
+
+        public Builder fileName(String fileName) {
+            this.fileName = fileName;
             return this;
         }
 
         public PortalDocument build() {
-            return new PortalDocument(title, fileName, fileType, document);
+            return new PortalDocument(
+                    title, documentType,
+                    fileName == null ? reduceToFileNameSafeChars(title) + "." + documentType.getFileExtension(): fileName,
+                    document);
         }
     }
 }

--- a/src/main/java/no/digipost/signature/client/portal/PortalJob.java
+++ b/src/main/java/no/digipost/signature/client/portal/PortalJob.java
@@ -54,7 +54,7 @@ public class PortalJob implements SignatureJob {
         List<Document> documents = new ArrayList<>();
         for (int i = 0; i < this.documents.size(); i++) {
             PortalDocument doc = this.documents.get(i);
-            documents.add(new Document(doc.title, doc.type,
+            documents.add(new Document(doc.title, doc.type.getMediaType(),
                     format("%04d", i) + "_" + reduceToFileNameSafeChars(doc.title) + "." + doc.type.getFileExtension(),
                     doc.document));
         }

--- a/src/main/java/no/digipost/signature/client/portal/PortalJob.java
+++ b/src/main/java/no/digipost/signature/client/portal/PortalJob.java
@@ -1,6 +1,7 @@
 package no.digipost.signature.client.portal;
 
 import no.digipost.signature.client.core.AuthenticationLevel;
+import no.digipost.signature.client.core.Document;
 import no.digipost.signature.client.core.IdentifierInSignedDocuments;
 import no.digipost.signature.client.core.Sender;
 import no.digipost.signature.client.core.SignatureJob;
@@ -13,8 +14,10 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import static java.lang.String.format;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.unmodifiableList;
+import static no.digipost.signature.client.core.internal.FileName.reduceToFileNameSafeChars;
 
 
 /**
@@ -47,7 +50,14 @@ public class PortalJob implements SignatureJob {
     }
 
     @Override
-    public List<PortalDocument> getDocuments() {
+    public List<Document> getDocuments() {
+        List<Document> documents = new ArrayList<>();
+        for (int i = 0; i < this.documents.size(); i++) {
+            PortalDocument doc = this.documents.get(i);
+            documents.add(new Document(doc.title, doc.type,
+                    format("%04d", i) + "_" + reduceToFileNameSafeChars(doc.title) + "." + doc.type.getFileExtension(),
+                    doc.document));
+        }
         return documents;
     }
 

--- a/src/test/java/no/digipost/signature/client/asice/CreateASiCETest.java
+++ b/src/test/java/no/digipost/signature/client/asice/CreateASiCETest.java
@@ -4,6 +4,7 @@ import no.digipost.signature.client.ClientConfiguration;
 import no.digipost.signature.client.asice.manifest.CreateDirectManifest;
 import no.digipost.signature.client.asice.manifest.CreatePortalManifest;
 import no.digipost.signature.client.asice.manifest.ManifestCreator;
+import no.digipost.signature.client.core.Document;
 import no.digipost.signature.client.core.DocumentType;
 import no.digipost.signature.client.core.Sender;
 import no.digipost.signature.client.core.SignatureJob;
@@ -31,16 +32,19 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
 import static java.nio.file.Files.newDirectoryStream;
+import static java.util.Arrays.asList;
+import static java.util.stream.Stream.concat;
 import static no.digipost.signature.client.TestKonfigurasjon.CLIENT_KEYSTORE;
 import static no.digipost.signature.client.asice.DumpDocumentBundleToDisk.TIMESTAMP_PATTERN;
 import static no.digipost.signature.client.asice.DumpDocumentBundleToDisk.referenceFilenamePart;
 import static no.digipost.signature.client.direct.ExitUrls.singleExitUrl;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 
 public class CreateASiCETest {
 
@@ -67,7 +71,10 @@ public class CreateASiCETest {
 
     @Test
     public void create_direct_asice_and_write_to_disk() throws IOException {
-        DirectJob job = DirectJob.builder("Job title", DIRECT_DOCUMENT, DirectSigner.withPersonalIdentificationNumber("12345678910").build(), singleExitUrl(URI.create("https://job.well.done.org")))
+        DirectJob job = DirectJob.builder("Job title",
+                    asList(DIRECT_DOCUMENT, DIRECT_DOCUMENT),
+                    asList(DirectSigner.withPersonalIdentificationNumber("12345678910").build()),
+                    singleExitUrl(URI.create("https://job.well.done.org")))
                 .withReference("direct job")
                 .build();
 
@@ -76,7 +83,9 @@ public class CreateASiCETest {
 
     @Test
     public void create_portal_asice_and_write_to_disk() throws IOException {
-        PortalJob job = PortalJob.builder("Job title", PORTAL_DOCUMENT, PortalSigner.identifiedByPersonalIdentificationNumber("12345678910", NotificationsUsingLookup.EMAIL_ONLY).build())
+        PortalJob job = PortalJob.builder("Job title",
+                    asList(PORTAL_DOCUMENT, PORTAL_DOCUMENT, PORTAL_DOCUMENT),
+                    asList(PortalSigner.identifiedByPersonalIdentificationNumber("12345678910", NotificationsUsingLookup.EMAIL_ONLY).build()))
                 .withReference("portal job")
                 .withDescription("Message")
                 .withActivationTime(clock.instant())
@@ -104,9 +113,10 @@ public class CreateASiCETest {
                 fileNames.add(entry.getName());
             }
         }
-        assertThat(fileNames, hasItem(job.getDocuments().get(0).getFileName()));
-        assertThat(fileNames, hasItem("manifest.xml"));
-        assertThat(fileNames, hasItem("META-INF/signatures.xml"));
+        assertThat(fileNames, containsInAnyOrder(concat(
+                    job.getDocuments().stream().map(Document::getFileName),
+                    Stream.of("manifest.xml", "META-INF/signatures.xml"))
+                .toArray(String[]::new)));
     }
 
 }

--- a/src/test/java/no/digipost/signature/client/asice/CreateASiCETest.java
+++ b/src/test/java/no/digipost/signature/client/asice/CreateASiCETest.java
@@ -4,7 +4,7 @@ import no.digipost.signature.client.ClientConfiguration;
 import no.digipost.signature.client.asice.manifest.CreateDirectManifest;
 import no.digipost.signature.client.asice.manifest.CreatePortalManifest;
 import no.digipost.signature.client.asice.manifest.ManifestCreator;
-import no.digipost.signature.client.core.Document;
+import no.digipost.signature.client.core.DocumentType;
 import no.digipost.signature.client.core.Sender;
 import no.digipost.signature.client.core.SignatureJob;
 import no.digipost.signature.client.direct.DirectDocument;
@@ -56,12 +56,12 @@ public class CreateASiCETest {
 
     private static Path dumpFolder;
 
-    private static final DirectDocument DIRECT_DOCUMENT = DirectDocument.builder("Document title", "file.txt", "hello".getBytes())
-            .fileType(Document.FileType.TXT)
+    private static final DirectDocument DIRECT_DOCUMENT = DirectDocument.builder("Document title", "hello".getBytes())
+            .type(DocumentType.TXT)
             .build();
 
-    private static final PortalDocument PORTAL_DOCUMENT = PortalDocument.builder("Document title", "file.txt", "hello".getBytes())
-            .fileType(Document.FileType.TXT)
+    private static final PortalDocument PORTAL_DOCUMENT = PortalDocument.builder("Document title", "hello".getBytes())
+            .type(DocumentType.TXT)
             .build();
 
 

--- a/src/test/java/no/digipost/signature/client/asice/archive/CreateZipTest.java
+++ b/src/test/java/no/digipost/signature/client/asice/archive/CreateZipTest.java
@@ -55,8 +55,8 @@ public class CreateZipTest {
             }
 
             @Override
-            public Type getType() {
-                return DocumentType.TXT;
+            public String getMediaType() {
+                return DocumentType.TXT.getMediaType();
             }
         };
     }

--- a/src/test/java/no/digipost/signature/client/asice/archive/CreateZipTest.java
+++ b/src/test/java/no/digipost/signature/client/asice/archive/CreateZipTest.java
@@ -1,6 +1,7 @@
 package no.digipost.signature.client.asice.archive;
 
 import no.digipost.signature.client.asice.ASiCEAttachable;
+import no.digipost.signature.client.core.DocumentType;
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Test;
 
@@ -41,7 +42,7 @@ public class CreateZipTest {
         assertArrayEquals(IOUtils.toByteArray(zipInputStream), contents.getBytes());
     }
 
-    private ASiCEAttachable file(final String fileName, final String contents) {
+    private ASiCEAttachable file(String fileName, String contents) {
         return new ASiCEAttachable() {
             @Override
             public String getFileName() {
@@ -54,8 +55,8 @@ public class CreateZipTest {
             }
 
             @Override
-            public String getMimeType() {
-                return "text/plain";
+            public Type getType() {
+                return DocumentType.TXT;
             }
         };
     }

--- a/src/test/java/no/digipost/signature/client/asice/manifest/CreateDirectManifestTest.java
+++ b/src/test/java/no/digipost/signature/client/asice/manifest/CreateDirectManifestTest.java
@@ -1,6 +1,5 @@
 package no.digipost.signature.client.asice.manifest;
 
-import no.digipost.signature.client.core.Document;
 import no.digipost.signature.client.core.IdentifierInSignedDocuments;
 import no.digipost.signature.client.core.Sender;
 import no.digipost.signature.client.direct.DirectDocument;
@@ -11,6 +10,7 @@ import org.junit.jupiter.api.Test;
 
 import java.net.URI;
 
+import static no.digipost.signature.client.core.DocumentType.TXT;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static uk.co.probablyfine.matchers.Java8Matchers.where;
@@ -21,9 +21,7 @@ class CreateDirectManifestTest {
     void accept_valid_manifest() {
         CreateDirectManifest createManifest = new CreateDirectManifest();
 
-        DirectDocument document = DirectDocument.builder("Title", "file.txt", "hello".getBytes())
-                .fileType(Document.FileType.TXT)
-                .build();
+        DirectDocument document = DirectDocument.builder("Title", "hello".getBytes()).type(TXT).build();
 
         DirectJob job = DirectJob.builder(
                     "Job title",

--- a/src/test/java/no/digipost/signature/client/asice/manifest/CreatePortalManifestTest.java
+++ b/src/test/java/no/digipost/signature/client/asice/manifest/CreatePortalManifestTest.java
@@ -1,6 +1,5 @@
 package no.digipost.signature.client.asice.manifest;
 
-import no.digipost.signature.client.core.Document;
 import no.digipost.signature.client.core.IdentifierInSignedDocuments;
 import no.digipost.signature.client.core.Sender;
 import no.digipost.signature.client.portal.NotificationsUsingLookup;
@@ -12,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import java.time.Clock;
 import java.time.Duration;
 
+import static no.digipost.signature.client.core.DocumentType.TXT;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static uk.co.probablyfine.matchers.Java8Matchers.where;
@@ -24,9 +24,7 @@ class CreatePortalManifestTest {
     void accept_valid_manifest() {
         CreatePortalManifest createManifest = new CreatePortalManifest(clock);
 
-        PortalDocument document = PortalDocument.builder("Title", "file.txt", "hello".getBytes())
-                .fileType(Document.FileType.TXT)
-                .build();
+        PortalDocument document = PortalDocument.builder("Title", "hello".getBytes()).type(TXT).build();
 
         PortalJob job = PortalJob.builder("Job title", document, PortalSigner.identifiedByPersonalIdentificationNumber("12345678910", NotificationsUsingLookup.EMAIL_ONLY).build())
                 .withActivationTime(clock.instant())

--- a/src/test/java/no/digipost/signature/client/asice/signature/CreateSignatureTest.java
+++ b/src/test/java/no/digipost/signature/client/asice/signature/CreateSignatureTest.java
@@ -55,8 +55,8 @@ public class CreateSignatureTest {
     public void setUp() {
         noekkelpar = TestKonfigurasjon.CLIENT_KEYSTORE;
         files = asList(
-                file("dokument.pdf", "hoveddokument-innhold".getBytes(), DocumentType.PDF),
-                file("manifest.xml", "manifest-innhold".getBytes(), ASiCEAttachable.Type.XML)
+                file("dokument.pdf", "hoveddokument-innhold".getBytes(), DocumentType.PDF.getMediaType()),
+                file("manifest.xml", "manifest-innhold".getBytes(), ASiCEAttachable.XML_MEDIATYPE)
         );
 
         ZonedDateTime signingTime = ZonedDateTime.of(2018, 11, 29, 9, 15, 0, 0, ZoneId.of("Europe/Oslo"));
@@ -103,8 +103,8 @@ public class CreateSignatureTest {
     @Test
     public void should_support_filenames_with_spaces_and_other_characters() {
         List<ASiCEAttachable> otherFiles = asList(
-                file("dokument (2).pdf", "hoveddokument-innhold".getBytes(), DocumentType.PDF),
-                file("manifest.xml", "manifest-innhold".getBytes(), ASiCEAttachable.Type.XML)
+                file("dokument (2).pdf", "hoveddokument-innhold".getBytes(), DocumentType.PDF.getMediaType()),
+                file("manifest.xml", "manifest-innhold".getBytes(), ASiCEAttachable.XML_MEDIATYPE)
         );
 
         Signature signature = createSignature.createSignature(otherFiles, noekkelpar);
@@ -161,14 +161,14 @@ public class CreateSignatureTest {
         assertThat(dokumentReference.getDigestMethod().getAlgorithm(), is("http://www.w3.org/2001/04/xmlenc#sha256"));
     }
 
-    private ASiCEAttachable file(String fileName, byte[] contents, ASiCEAttachable.Type type) {
+    private ASiCEAttachable file(String fileName, byte[] contents, String mediaType) {
         return new ASiCEAttachable() {
             @Override
             public String getFileName() { return fileName; }
             @Override
             public byte[] getBytes() { return contents; }
             @Override
-            public Type getType() { return type; }
+            public String getMediaType() { return mediaType; }
         };
     }
 

--- a/src/test/java/no/digipost/signature/client/asice/signature/CreateSignatureTest.java
+++ b/src/test/java/no/digipost/signature/client/asice/signature/CreateSignatureTest.java
@@ -11,6 +11,7 @@ import no.digipost.signature.api.xml.thirdparty.xmldsig.SignedInfo;
 import no.digipost.signature.api.xml.thirdparty.xmldsig.X509IssuerSerialType;
 import no.digipost.signature.client.TestKonfigurasjon;
 import no.digipost.signature.client.asice.ASiCEAttachable;
+import no.digipost.signature.client.core.DocumentType;
 import no.digipost.signature.client.security.KeyStoreConfig;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -26,12 +27,12 @@ import java.time.ZonedDateTime;
 import java.util.Base64;
 import java.util.List;
 
-import static uk.co.probablyfine.matchers.Java8Matchers.where;
 import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static uk.co.probablyfine.matchers.Java8Matchers.where;
 
 public class CreateSignatureTest {
 
@@ -54,8 +55,8 @@ public class CreateSignatureTest {
     public void setUp() {
         noekkelpar = TestKonfigurasjon.CLIENT_KEYSTORE;
         files = asList(
-                file("dokument.pdf", "hoveddokument-innhold".getBytes(), "application/pdf"),
-                file("manifest.xml", "manifest-innhold".getBytes(), "application/xml")
+                file("dokument.pdf", "hoveddokument-innhold".getBytes(), DocumentType.PDF),
+                file("manifest.xml", "manifest-innhold".getBytes(), ASiCEAttachable.Type.XML)
         );
 
         ZonedDateTime signingTime = ZonedDateTime.of(2018, 11, 29, 9, 15, 0, 0, ZoneId.of("Europe/Oslo"));
@@ -102,8 +103,8 @@ public class CreateSignatureTest {
     @Test
     public void should_support_filenames_with_spaces_and_other_characters() {
         List<ASiCEAttachable> otherFiles = asList(
-                file("dokument (2).pdf", "hoveddokument-innhold".getBytes(), "application/pdf"),
-                file("manifest.xml", "manifest-innhold".getBytes(), "application/xml")
+                file("dokument (2).pdf", "hoveddokument-innhold".getBytes(), DocumentType.PDF),
+                file("manifest.xml", "manifest-innhold".getBytes(), ASiCEAttachable.Type.XML)
         );
 
         Signature signature = createSignature.createSignature(otherFiles, noekkelpar);
@@ -160,14 +161,14 @@ public class CreateSignatureTest {
         assertThat(dokumentReference.getDigestMethod().getAlgorithm(), is("http://www.w3.org/2001/04/xmlenc#sha256"));
     }
 
-    private ASiCEAttachable file(final String fileName, final byte[] contents, final String mimeType) {
+    private ASiCEAttachable file(String fileName, byte[] contents, ASiCEAttachable.Type type) {
         return new ASiCEAttachable() {
             @Override
             public String getFileName() { return fileName; }
             @Override
             public byte[] getBytes() { return contents; }
             @Override
-            public String getMimeType() { return mimeType; }
+            public Type getType() { return type; }
         };
     }
 

--- a/src/test/java/no/digipost/signature/client/core/internal/FileNameTest.java
+++ b/src/test/java/no/digipost/signature/client/core/internal/FileNameTest.java
@@ -1,0 +1,71 @@
+package no.digipost.signature.client.core.internal;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+
+import static no.digipost.signature.client.core.internal.FileName.reduceToFileNameSafeChars;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.quicktheories.QuickTheory.qt;
+import static org.quicktheories.generators.SourceDSL.strings;
+
+class FileNameTest {
+
+    @Test
+    void convertsToLowerCase() {
+        assertThat(reduceToFileNameSafeChars("Title"), is("title"));
+    }
+
+    @Test
+    void replacesNorwegianCharacters() {
+        assertThat(reduceToFileNameSafeChars("ÆØÅ"), is("aeoeaa"));
+        assertThat(reduceToFileNameSafeChars("æøå"), is("aeoeaa"));
+    }
+
+    @Test
+    void successiveSpacesIsReplacedWithAnUnderscore() {
+        assertThat(reduceToFileNameSafeChars("Hei   på \t  Deg"), is("hei_paa_deg"));
+    }
+
+    @Test
+    void successivePunctuationIsReplacedWithAnUnderscore() {
+        assertThat(reduceToFileNameSafeChars("*@,:;&%$^?+=()[]{}#\"“”!`´<>"), is("_"));
+    }
+
+    @Test
+    void emptyNameIsAnError() {
+        assertThrows(IllegalArgumentException.class, () -> reduceToFileNameSafeChars(""));
+        assertThrows(IllegalArgumentException.class, () -> reduceToFileNameSafeChars(null));
+    }
+
+    @Test
+    void accentsAndOtherDiacriticalMarksAreRemoved() {
+        assertThat(reduceToFileNameSafeChars("àáëêÈÉüÜïñÑ"), is("aaeeeeuuinn"));
+    }
+
+    @Test
+    void periodAndDashAreKeptAsIs() {
+        assertThat(reduceToFileNameSafeChars("Morse ...---..."), is("morse_...---..."));
+    }
+
+    @Test
+    void urlEncodingWillAlwaysProduceSameString() {
+        qt()
+            .forAll(strings().allPossible().ofLengthBetween(1, 100))
+            .as(FileName::reduceToFileNameSafeChars)
+            .checkAssert(safeFileName -> assertThat(urlEncode(safeFileName), equalTo(safeFileName)));
+    }
+
+    private static String urlEncode(String s) {
+        try {
+            return URLEncoder.encode(s, "UTF-8");
+        } catch (UnsupportedEncodingException utf8NotSupported) {
+            throw new RuntimeException(utf8NotSupported.getMessage(), utf8NotSupported);
+        }
+    }
+
+}

--- a/src/test/java/no/digipost/signature/client/docs/DirectClientUseCases.java
+++ b/src/test/java/no/digipost/signature/client/docs/DirectClientUseCases.java
@@ -32,7 +32,7 @@ class DirectClientUseCases {
         DirectClient client = new DirectClient(clientConfiguration);
 
         byte[] documentBytes = null; // Loaded document bytes
-        DirectDocument document = DirectDocument.builder("Document title", "document.pdf", documentBytes).build();
+        DirectDocument document = DirectDocument.builder("Document title", documentBytes).build();
 
         ExitUrls exitUrls = ExitUrls.of(
                 URI.create("http://sender.org/onCompletion"),

--- a/src/test/java/no/digipost/signature/client/docs/PortalClientUseCases.java
+++ b/src/test/java/no/digipost/signature/client/docs/PortalClientUseCases.java
@@ -29,7 +29,7 @@ class PortalClientUseCases {
         PortalClient client = new PortalClient(clientConfiguration);
 
         byte[] documentBytes = null; // Loaded document bytes
-        PortalDocument document = PortalDocument.builder("Document title", "document.pdf", documentBytes).build();
+        PortalDocument document = PortalDocument.builder("Document title", documentBytes).build();
 
         PortalJob portalJob = PortalJob.builder(
                 "Job title",
@@ -99,7 +99,7 @@ class PortalClientUseCases {
         Sender sender = new Sender("000000000", PollingQueue.of("CustomPollingQueue"));
 
         byte[] documentBytes = null; // Loaded document bytes
-        PortalDocument document = PortalDocument.builder("Document title", "document.pdf", documentBytes).build();
+        PortalDocument document = PortalDocument.builder("Document title", documentBytes).build();
 
         PortalJob portalJob = PortalJob.builder(
                 "Job title",


### PR DESCRIPTION
The creation of the ASiCE document bundle is internal to the library, and the user of the library should not need to bother about giving "file names" for each document of a job. This will instead construct file names based on the documents' titles, by doing a best effort of reducing each character to an ASCII'ish "equivalent" (é -> e, ü -> u, etc), and lastly mapping if necessary each remeaining character to an allowed alphabet of `[a-z][0-9][-_.]`.

The document file names inside the zip looks like this:
- `0000_title_of_first_document.pdf`
- `0001_title_of_second_document.pdf`
- ...