### PR TITLE
Include HK2 InjectionManager

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -8,28 +8,34 @@ Licensed under Apache 2 - http://www.apache.org/licenses/LICENSE-2.0.html
 
 This software includes third party software subject to the following licenses:
 
+  aopalliance version 1.0 repackaged as a module under EPL 2.0 or GPL2 w/ CPE
   Apache Commons Codec under Apache License, Version 2.0
   Apache Commons Lang under Apache License, Version 2.0
   Apache HttpClient under Apache License, Version 2.0
   Apache HttpCore under Apache License, Version 2.0
+  HK2 API module under EPL 2.0 or GPL2 w/ CPE
+  HK2 Implementation Utilities under EPL 2.0 or GPL2 w/ CPE
   istack common utility code runtime under Eclipse Distribution License - v 1.0
   Jakarta Activation under EDL 1.0
   Jakarta Activation API jar under EDL 1.0
   Jakarta Annotations API under EPL 2.0 or GPL2 w/ CPE
   Jakarta XML Binding API under Eclipse Distribution License - v 1.0
   jakarta.ws.rs-api under EPL 2.0 or GPL2 w/ CPE
+  Javassist under MPL 1.1 or LGPL 2.1 or Apache License 2.0
   javax.inject:1 as OSGi bundle under EPL 2.0 or GPL2 w/ CPE
   JAXB Runtime under Eclipse Distribution License - v 1.0
   JAXB2 Basics - Runtime under BSD-Style License
   JCL 1.2 implemented over SLF4J under Apache License, Version 2.0
   jersey-core-client under EPL 2.0 or GPL2 w/ CPE or EDL 1.0 or BSD 2-Clause or Apache License, 2.0 or Public Domain or Modified BSD or jQuery license or MIT license or W3C license
   jersey-core-common under EPL 2.0 or The GNU General Public License (GPL), Version 2, With Classpath Exception or Apache License, 2.0 or Public Domain
+  jersey-inject-hk2 under EPL 2.0 or GPL2 w/ CPE or EDL 1.0 or BSD 2-Clause or Apache License, 2.0 or Public Domain or Modified BSD or jQuery license or MIT license or W3C license
   jersey-media-multipart under EPL 2.0 or GPL2 w/ CPE or EDL 1.0 or BSD 2-Clause or Apache License, 2.0 or Public Domain or Modified BSD or jQuery license or MIT license or W3C license
   MIME streaming extension under Eclipse Distribution License - v 1.0
   OSGi resource locator under EPL 2.0 or GPL2 w/ CPE
   Posten signering - API JAXB Classes under The Apache Software License, Version 2.0
   Posten signering - API Schema under The Apache Software License, Version 2.0
   Posten signering - Java API Client Library under The Apache Software License, Version 2.0
+  ServiceLocator Default Implementation under EPL 2.0 or GPL2 w/ CPE
   SLF4J API Module under MIT License
   Spring AOP under Apache License, Version 2.0
   Spring Beans under Apache License, Version 2.0

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,11 @@
             <artifactId>jersey-media-multipart</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.glassfish.jersey.inject</groupId>
+            <artifactId>jersey-hk2</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>2.10.0</version>

--- a/src/main/java/no/digipost/signature/client/core/internal/http/SignatureHttpClientFactory.java
+++ b/src/main/java/no/digipost/signature/client/core/internal/http/SignatureHttpClientFactory.java
@@ -20,7 +20,17 @@ public class SignatureHttpClientFactory {
                 .hostnameVerifier(NoopHostnameVerifier.INSTANCE)
                 .build();
 
-        jerseyClient.preInitialize();
+        try {
+            jerseyClient.preInitialize();
+        } catch (Exception e) {
+            throw new IllegalStateException(
+                    "Unable to pre-initialize Jersey Client, because " + e.getClass().getSimpleName() + " '" + e.getMessage() + "'. " +
+                    "This step is taken to ensure everything the client needs is available already on instantiation, " +
+                    "in particular the InjectionManager facilities used internally by Jersey. By default, the Signature API Client " +
+                    "should include the Jersey HK2 implementation, but if you need to control this yourself, consider excluding " +
+                    "org.glassfish.jersey.inject:jersey-hk2 when depending on the signature-api-client-java, and make sure to make the " +
+                    "InjectionManagerFactory of your choice discoverable by Jersey.", e);
+        }
         return new DefaultClient(jerseyClient, config.getServiceRoot());
     }
 

--- a/src/main/java/no/digipost/signature/client/core/internal/http/SignatureHttpClientFactory.java
+++ b/src/main/java/no/digipost/signature/client/core/internal/http/SignatureHttpClientFactory.java
@@ -1,6 +1,7 @@
 package no.digipost.signature.client.core.internal.http;
 
 import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.glassfish.jersey.client.JerseyClient;
 import org.glassfish.jersey.client.JerseyClientBuilder;
 
 import javax.ws.rs.client.Client;
@@ -12,11 +13,14 @@ public class SignatureHttpClientFactory {
 
 
     public static SignatureHttpClient create(HttpIntegrationConfiguration config) {
-        Client jerseyClient = JerseyClientBuilder.newBuilder()
+        JerseyClientBuilder jerseyBuilder = (JerseyClientBuilder) JerseyClientBuilder.newBuilder();
+        JerseyClient jerseyClient = jerseyBuilder
                 .withConfig(config.getJaxrsConfiguration())
                 .sslContext(config.getSSLContext())
                 .hostnameVerifier(NoopHostnameVerifier.INSTANCE)
                 .build();
+
+        jerseyClient.preInitialize();
         return new DefaultClient(jerseyClient, config.getServiceRoot());
     }
 

--- a/src/test/java/no/digipost/signature/client/core/internal/http/SignatureHttpClientFactoryTest.java
+++ b/src/test/java/no/digipost/signature/client/core/internal/http/SignatureHttpClientFactoryTest.java
@@ -1,0 +1,48 @@
+package no.digipost.signature.client.core.internal.http;
+
+import org.glassfish.jersey.client.ClientConfig;
+import org.junit.jupiter.api.Test;
+
+import javax.net.ssl.SSLContext;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Configuration;
+
+import java.net.URI;
+import java.security.NoSuchAlgorithmException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static uk.co.probablyfine.matchers.Java8Matchers.where;
+
+public class SignatureHttpClientFactoryTest implements HttpIntegrationConfiguration {
+
+    @Test
+    void instantiatesSignatureHttpClient() {
+        SignatureHttpClient signatureHttpClient = SignatureHttpClientFactory.create(this);
+        WebTarget target = signatureHttpClient.signatureServiceRoot();
+        assertThat(target, where(WebTarget::getUri, is(this.getServiceRoot())));
+    }
+
+
+
+
+    @Override
+    public Configuration getJaxrsConfiguration() {
+        return new ClientConfig();
+    }
+
+    @Override
+    public SSLContext getSSLContext() {
+        try {
+            return SSLContext.getDefault();
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public URI getServiceRoot() {
+        return URI.create("localhost");
+    }
+
+}

--- a/src/test/java/no/digipost/signature/client/core/internal/http/SignatureHttpClientFactoryTest.java
+++ b/src/test/java/no/digipost/signature/client/core/internal/http/SignatureHttpClientFactoryTest.java
@@ -24,8 +24,6 @@ public class SignatureHttpClientFactoryTest implements HttpIntegrationConfigurat
     }
 
 
-
-
     @Override
     public Configuration getJaxrsConfiguration() {
         return new ClientConfig();


### PR DESCRIPTION
Needed by Jersey.
Also does preinitialization of the Jersey client, to avoid having it break later when doing an actual request, as this may happen long after an application is started and evaluated as "healthy". The new `SignatureHttpClientFactoryTest` tests this a bit implicitly, as it will only be able to instantiate the client if the HK2-dependency is included.