### PR TITLE
Readme fixup

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,38 @@
 ![](https://github.com/digipost/signature-api-client-java/workflows/Build%20and%20deploy/badge.svg)
 [![License](https://img.shields.io/badge/license-Apache%202-blue)](https://github.com/digipost/signature-api-client-java/blob/main/LICENCE)
 
-This repo is the Java client library for integrating with Posten signering. Please see [signature-api-client-dotnet](https://github.com/digipost/signature-api-client-dotnet) for the C# version.
+This repo is the Java client library for integrating with **Posten signering**.
 
-## 📕 Documentation
+If you are looking for the C# variant of this library, please see [signature-api-client-dotnet](https://github.com/digipost/signature-api-client-dotnet).
+
+## Documentation
 
 Get started by [reading the documentation](http://signering-docs.rtfd.io/).
+
+
+## Dependency
+
+The recommended way to declare dependency on the library is to utilize the [BOM](https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#bill-of-materials-bom-poms). With Maven, this is declared like this:
+
+```xml
+<dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>no.digipost.signature</groupId>
+            <artifactId>signature-api-client-bom</artifactId>
+            <version>7.0.1</version> <!-- replace with any later version -->
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+...
+```
+
+And depend directly on the library artifact (without any specified version, since this is supplied by the BOM artifact above)
+```xml
+<dependencies>
+    <dependency>
+        <groupId>no.digipost.signature</groupId>
+        <artifactId>signature-api-client-java</artifactId>
+    </dependency>
+...
+```

--- a/README.md
+++ b/README.md
@@ -8,7 +8,3 @@ This repo is the Java client library for integrating with Posten signering. Plea
 ## 📕 Documentation
 
 Get started by [reading the documentation](http://signering-docs.rtfd.io/).
- 
-## Releasing (only for Digipost members)
-
-See docs/systemer/open-source-biblioteker.md

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Posten Signering – Java client Library
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/no.digipost.signature/signature-api-client-java/badge.svg)](https://maven-badges.herokuapp.com/maven-central/no.digipost.signature/signature-api-client-java)
+[![javadoc](https://javadoc.io/badge2/no.digipost.signature/signature-api-client-java/javadoc.svg?logo=java&color=yellow)](https://javadoc.io/doc/no.digipost.signature/signature-api-client-java)
 ![](https://github.com/digipost/signature-api-client-java/workflows/Build%20and%20deploy/badge.svg)
 [![License](https://img.shields.io/badge/license-Apache%202-blue)](https://github.com/digipost/signature-api-client-java/blob/main/LICENCE)
 

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -188,7 +188,7 @@
                 <plugin>
                     <groupId>com.github.siom79.japicmp</groupId>
                     <artifactId>japicmp-maven-plugin</artifactId>
-                    <version>0.17.3</version>
+                    <version>0.18.1</version>
                     <configuration>
                         <parameter>
                             <includes>
@@ -202,7 +202,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-shade-plugin</artifactId>
-                    <version>3.5.0</version>
+                    <version>3.5.1</version>
                     <configuration>
                         <minimizeJar>true</minimizeJar>
                         <artifactSet>
@@ -236,7 +236,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.5.0</version>
+                    <version>3.6.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-jar-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>versions-maven-plugin</artifactId>
-                    <version>2.16.0</version>
+                    <version>2.16.1</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
Minor cleanup in the readme for the repository.

- includes the recommended way to depend on the library by utilizing the provided BOM.
- adds a badge with link to javadocs.
- removes a reference to internal documentation for Posten.

# Before
<img width="550" alt="readme-before" src="https://github.com/digipost/signature-api-client-java/assets/174823/6d620152-4843-4319-b750-16feef663ef9">

# After
<img width="582" alt="readme-after" src="https://github.com/digipost/signature-api-client-java/assets/174823/0f906b38-5459-45f6-a5b7-0e8d43f38eba">

