### PR TITLE
Less drama, more information

### DIFF
--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>no.digipost</groupId>
             <artifactId>certificate-validator</artifactId>
-            <version>3.0.2</version>
+            <version>3.0.3</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.bouncycastle</groupId>
@@ -72,13 +72,13 @@
         <dependency>
             <groupId>org.apache.httpcomponents.core5</groupId>
             <artifactId>httpcore5</artifactId>
-            <version>5.2.2</version>
+            <version>5.2.3</version>
         </dependency>
 
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.13.0</version>
+            <version>2.14.0</version>
             <scope>test</scope>
         </dependency>
 
@@ -124,7 +124,7 @@
         <dependency>
             <groupId>nl.jqno.equalsverifier</groupId>
             <artifactId>equalsverifier</artifactId>
-            <version>3.15.1</version>
+            <version>3.15.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/lib/src/main/java/no/digipost/signature/client/ServiceEnvironment.java
+++ b/lib/src/main/java/no/digipost/signature/client/ServiceEnvironment.java
@@ -87,7 +87,7 @@ public final class ServiceEnvironment implements ProvidesCertificateResourcePath
 }
 
 
-enum Certificates implements ProvidesCertificateResourcePaths {
+enum Certificates {
 
     TEST(
             "test/Buypass_Class_3_Test4_CA_3.cer",
@@ -123,11 +123,6 @@ enum Certificates implements ProvidesCertificateResourcePaths {
         this.certificatePaths = Stream.of(certificatePaths)
                 .map("classpath:/certificates/"::concat)
                 .collect(toList());
-    }
-
-    @Override
-    public List<String> certificatePaths() {
-        return certificatePaths();
     }
 
 }

--- a/lib/src/main/java/no/digipost/signature/client/security/OrganizationNumberValidation.java
+++ b/lib/src/main/java/no/digipost/signature/client/security/OrganizationNumberValidation.java
@@ -28,7 +28,7 @@ public class OrganizationNumberValidation implements CertificateChainValidation 
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + " trusting '" + trustedOrganizationNumber + "'";
+        return getClass().getSimpleName() + " trusting organization number '" + trustedOrganizationNumber + "'";
     }
 
 }


### PR DESCRIPTION
More informational (and a bit less dramatic) message if the client refuses to trust the TLS server certificate.

E.g. if attempting to use a Posten signering web site URL in place of an API URL, the exception now looks like:
```
no.digipost.signature.client.core.exceptions.HttpIOException:
Error executing POST https://difitest.signering.posten.no/, because SSLException 
'Untrusted server certificate, according to OrganizationNumberValidation trusting organization number '984661185'.
Actual certificate from server response: CN=difitest.signering.posten.no
(serial number 266807810224456931373439957111026753236316, expires 2024-01-08T12:27:38+01:00[Europe/Oslo]),
issued by CN=R3, O=Let's Encrypt, C=US.
This normally indicates either a misconfiguration of this client library, or a mixup of URLs used to communicate with the API.
Make sure the request URL is correct, is actually for the API, and it aligns with the configured ServiceEnvironment.
It should e.g. not be a URL that is to be accessed by a user from a web browser.'
	at no.digipost.signature.client.core.internal.ClientHelper.requestNewRedirectUrl(ClientHelper.java:124)
	at no.digipost.signature.client.direct.DirectClient.requestNewRedirectUrl(DirectClient.java:54)
        ...
```

Notably, this removes a mention of a possible man-in-the-middle attack, and also contains some more hints on how to resolve the error.

This PR will solve and close #199 