### PR TITLE
Ensure only NOOP hostname verifier is used for TLS

### DIFF
--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -28,7 +28,7 @@
             <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
-                <version>5.13.0-M2</version>
+                <version>5.14.2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -74,18 +74,18 @@
         <dependency>
             <groupId>org.apache.httpcomponents.client5</groupId>
             <artifactId>httpclient5</artifactId>
-            <version>5.4.4</version>
+            <version>5.6</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents.core5</groupId>
             <artifactId>httpcore5</artifactId>
-            <version>5.3.4</version>
+            <version>5.4</version>
         </dependency>
 
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.19.0</version>
+            <version>2.21.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -183,12 +183,12 @@
             <plugins>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.14.0</version>
+                    <version>3.14.1</version>
                 </plugin>
                 <plugin>
                     <groupId>com.github.siom79.japicmp</groupId>
                     <artifactId>japicmp-maven-plugin</artifactId>
-                    <version>0.23.1</version>
+                    <version>0.24.2</version>
                     <configuration>
                         <parameter>
                             <includes>
@@ -202,7 +202,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-shade-plugin</artifactId>
-                    <version>3.6.0</version>
+                    <version>3.6.1</version>
                     <configuration>
                         <minimizeJar>true</minimizeJar>
                         <artifactSet>
@@ -228,15 +228,15 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.5.3</version>
+                    <version>3.5.4</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-resources-plugin</artifactId>
-                    <version>3.3.1</version>
+                    <version>3.4.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.11.2</version>
+                    <version>3.12.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-jar-plugin</artifactId>
@@ -244,7 +244,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>3.6.1</version>
+                    <version>3.6.2</version>
                     <configuration>
                         <rules>
                             <bannedDependencies>

--- a/lib/src/main/java/no/digipost/signature/client/core/internal/configuration/ApacheHttpClientSslConfigurer.java
+++ b/lib/src/main/java/no/digipost/signature/client/core/internal/configuration/ApacheHttpClientSslConfigurer.java
@@ -9,6 +9,7 @@ import no.digipost.signature.client.security.KeyStoreConfig;
 import no.digipost.signature.client.security.OrganizationNumberValidation;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
 import org.apache.hc.client5.http.ssl.DefaultClientTlsStrategy;
+import org.apache.hc.client5.http.ssl.HostnameVerificationPolicy;
 import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
 import org.apache.hc.core5.ssl.SSLContexts;
 
@@ -40,7 +41,8 @@ public class ApacheHttpClientSslConfigurer implements Configurer<PoolingHttpClie
 
     @Override
     public void applyTo(PoolingHttpClientConnectionManagerBuilder connectionManager) {
-        connectionManager.setTlsSocketStrategy(new DefaultClientTlsStrategy(sslContext(), NoopHostnameVerifier.INSTANCE));
+        connectionManager.setTlsSocketStrategy(
+                new DefaultClientTlsStrategy(sslContext(), HostnameVerificationPolicy.CLIENT, NoopHostnameVerifier.INSTANCE));
     }
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>no.digipost</groupId>
         <artifactId>digipost-open-super-pom</artifactId>
-        <version>14</version>
+        <version>15</version>
     </parent>
 
     <groupId>no.digipost.signature</groupId>
@@ -68,7 +68,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.8.1</version>
+                    <version>3.9.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-install-plugin</artifactId>
@@ -77,7 +77,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>versions-maven-plugin</artifactId>
-                    <version>2.18.0</version>
+                    <version>2.20.1</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
Because of Signering API using non-standard server certificate for establishing TLS connection, i.e. enterprise certificates (virksomhetssertifikat).

Apache Http Client [changed behavior in v5.6 (see "Compatibility notes" in announcement)](https://lists.apache.org/thread/xycs1swxpdc4g3255ms0p1kshbl3ky29), where it is not enough to configure your own `HostnameVerifier`. To avoid the verification which is built-in into the JDK SSL stack, one must explicitly configure this policy to [HostnameVerificationPolicy.CLIENT](https://javadoc.io/static/org.apache.httpcomponents.client5/httpclient5/5.6/org/apache/hc/client5/http/ssl/HostnameVerificationPolicy.html).

https://github.com/apache/httpcomponents-client/commit/d89fdfeb6f66a20aefac6b50375e30613b2fc08b

This is a backward compatible change, and signature-api-client-java can still be used with previous minor-versions of Apache Http client.